### PR TITLE
User types

### DIFF
--- a/SSA/WellTypedFramework.lean
+++ b/SSA/WellTypedFramework.lean
@@ -1,12 +1,12 @@
 import SSA.Framework
 import Mathlib.Data.Option.Basic
 
-class BaseTypeClass (BaseType : Type) : Type 1 where
+class BaseTypeClass (BaseType : Type) [DecidableEq BaseType] : Type 1 where
   toType : BaseType → Type
 
 instance : BaseTypeClass Unit where toType := fun _ => Unit
 
-inductive UserType (T : Type) [BaseTypeClass T]: Type where
+inductive UserType (T : Type) [DecidableEq T] [BaseTypeClass T] : Type where
   | base : T → UserType T
   | pair : UserType T → UserType T → UserType T
   | triple : UserType T → UserType T → UserType T → UserType T
@@ -14,44 +14,44 @@ inductive UserType (T : Type) [BaseTypeClass T]: Type where
 
 namespace UserType
 
-instance {BaseType : Type} [BaseTypeClass BaseType]: Inhabited (UserType BaseType) where default := UserType.unit
+instance {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType]: Inhabited (UserType BaseType) where default := UserType.unit
 
-def toType {BaseType : Type} [BaseTypeClass BaseType] : UserType BaseType → Type
+def toType {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] : UserType BaseType → Type
   | .base t => BaseTypeClass.toType t
   | .pair k₁ k₂ => (toType k₁) × (toType k₂)
   | .triple k₁ k₂ k₃ => toType k₁ × toType k₂ × toType k₃
   | .unit => Unit
 
-def mkPair {BaseType : Type} [BaseTypeClass BaseType] {k₁ k₂ : UserType BaseType}: toType k₁ → toType k₂ → toType (.pair k₁ k₂)
+def mkPair {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] {k₁ k₂ : UserType BaseType}: toType k₁ → toType k₂ → toType (.pair k₁ k₂)
   | k₁, k₂ => (k₁, k₂)
 
-def mkTriple {BaseType : Type} [BaseTypeClass BaseType] {k₁ k₂ k₃ : UserType BaseType}: toType k₁ → toType k₂ → toType k₃ → toType (.triple k₁ k₂ k₃)
+def mkTriple {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] {k₁ k₂ k₃ : UserType BaseType}: toType k₁ → toType k₂ → toType k₃ → toType (.triple k₁ k₂ k₃)
   | k₁, k₂, k₃ => (k₁, k₂, k₃)
 
-def fstPair {BaseType : Type} [BaseTypeClass BaseType] {k₁ k₂ : UserType BaseType} : toType (.pair k₁ k₂) → toType k₁
+def fstPair {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] {k₁ k₂ : UserType BaseType} : toType (.pair k₁ k₂) → toType k₁
   | (k₁, _) => k₁
 
-def sndPair {BaseType : Type} [BaseTypeClass BaseType] {k₁ k₂ : UserType BaseType} : toType (.pair k₁ k₂) → toType k₂
+def sndPair {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] {k₁ k₂ : UserType BaseType} : toType (.pair k₁ k₂) → toType k₂
   | (_, k₂) => k₂
 
-def fstTriple {BaseType : Type} [BaseTypeClass BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₁
+def fstTriple {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₁
   | (k₁, _, _) => k₁
 
-def sndTriple {BaseType : Type} [BaseTypeClass BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₂
+def sndTriple {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₂
   | (_, k₂, _) => k₂
 
-def trdTriple {BaseType : Type} [BaseTypeClass BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₃
+def trdTriple {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₃
   | (_, _, k₃) => k₃
 
 end UserType
 
 
-structure UserData {BaseType : Type} [BaseTypeClass BaseType] where
+structure UserData {BaseType : Type} [DecidableEq BaseType] [BaseTypeClass BaseType] where
   type : UserType BaseType
   value : type.toType
 
 
-inductive  TypeData (BaseType : Type) [BaseTypeClass BaseType] : Type
+inductive  TypeData (BaseType : Type) [DecidableEq BaseType] [BaseTypeClass BaseType] : Type
   | some : BaseType → TypeData BaseType
   | unit : TypeData BaseType
   | pair : TypeData BaseType → TypeData BaseType → TypeData BaseType
@@ -60,84 +60,69 @@ inductive  TypeData (BaseType : Type) [BaseTypeClass BaseType] : Type
   | unused : TypeData BaseType -- Or bound
 
 @[coe]
-def UserType.toTypeData [BaseTypeClass BaseType] : UserType BaseType → TypeData BaseType
+def UserType.toTypeData [DecidableEq BaseType] [BaseTypeClass BaseType] : UserType BaseType → TypeData BaseType
   | UserType.base t => TypeData.some t
   | UserType.unit => TypeData.unit
   | UserType.pair k₁ k₂ => TypeData.pair (UserType.toTypeData k₁) (UserType.toTypeData k₂)
   | UserType.triple k₁ k₂ k₃ => TypeData.triple (UserType.toTypeData k₁) (UserType.toTypeData k₂)
     (UserType.toTypeData k₃)
 
-variable {BaseType : Type} [instBaseTypeClass : BaseTypeClass BaseType]
+variable {BaseType : Type} [instDecidableEqBaseType : DecidableEq BaseType] [instBaseTypeClass : BaseTypeClass BaseType]
 instance : Coe (UserType BaseType) (TypeData BaseType) := ⟨UserType.toTypeData⟩
 
-def TypeSemantics : Type 1 :=
-  ℕ → Type
-
-inductive NatBaseType (TS : TypeSemantics) : Type
-  | ofNat : ℕ → NatBaseType TS
-deriving DecidableEq
-
-instance : BaseTypeClass (NatBaseType TS) where toType :=
-  fun n => match n with
-    | .ofNat m => TS m
-
-class TypedUserSemantics (Op : Type) (TS : TypeSemantics) where
-  argKind : Op → UserType (NatBaseType TS)
-  rgnDom : Op → UserType (NatBaseType TS)
-  rgnCod : Op → UserType (NatBaseType TS)
-  outKind : Op → UserType (NatBaseType TS)
+class TypedUserSemantics (Op : Type) (BaseType : Type) [DecidableEq BaseType] [BaseTypeClass BaseType] where
+  argKind : Op → UserType BaseType
+  rgnDom : Op → UserType BaseType
+  rgnCod : Op → UserType BaseType
+  outKind : Op → UserType BaseType
   eval : ∀ (o : Op), (argKind o).toType → ((rgnDom o).toType →
     (rgnCod o).toType) → (outKind o).toType
 
-variable (TS : TypeSemantics)
-abbrev NatUserType := UserType (NatBaseType TS)
-abbrev NatTypeData := TypeData (NatBaseType TS)
-
 @[simp]
-def NatTypeData.toType (TS : TypeSemantics) : @NatTypeData TS → Type
-  | TypeData.some (.ofNat k) => TS k
+def TypeData.toType : TypeData BaseType → Type
+  | TypeData.some t => BaseTypeClass.toType t
   | TypeData.unit => Unit
-  | TypeData.pair t₁ t₂ => (NatTypeData.toType TS t₁) × (NatTypeData.toType TS t₂)
-  | TypeData.triple t₁ t₂ t₃ => (NatTypeData.toType TS t₁) × (NatTypeData.toType TS t₂) × (NatTypeData.toType TS t₃)
-  | TypeData.any => Σ (k : NatUserType TS), @UserType.toType (@NatBaseType TS) (@instBaseTypeClassNatBaseType TS) k
+  | TypeData.pair t₁ t₂ => (TypeData.toType  t₁) × (TypeData.toType t₂)
+  | TypeData.triple t₁ t₂ t₃ => (TypeData.toType t₁) × (TypeData.toType t₂) × (TypeData.toType t₃)
+  | TypeData.any => Σ (k : UserType BaseType), @UserType.toType BaseType instDecidableEqBaseType instBaseTypeClass k
   | TypeData.unused => Unit
 
-/- Kind.toType = Kind.toTypeData.toType -/
-theorem NatTypeDataToTypeEqTypeDataToType (a : NatUserType TS) : a.toType = NatTypeData.toType TS a.toTypeData := by
-  induction a with
-  | base n => rfl
-  | unit => rfl
-  | pair k₁ k₂ ih₁ ih₂ => simp [NatTypeData.toType, UserType.toType, ih₁, ih₂]
-  | triple k₁ k₂ k₂ ih₁ ih₂ ih₃ => simp [NatTypeData.toType, UserType.toType, ih₁, ih₂, ih₃]
+theorem TypeDataToTypeEqUserTypeToType (a : UserType BaseType) : a.toType = TypeData.toType a.toTypeData :=
+  by
+    induction a <;> (try rfl)
+    case pair k₁ k₂ ih₁ ih₂ => simp [TypeData.toType, UserType.toType, ih₁, ih₂]
+    case triple k₁ k₂ k₃ ih₁ ih₂ ih₃ => simp [TypeData.toType, UserType.toType, ih₁, ih₂, ih₃]
+
 
 @[simp]
-def SSAIndex.ieval (Op : Type) (TS : TypeSemantics)
-    [TypedUserSemantics Op TS] : SSAIndex → Type
-  | .TERMINATOR => TypeData (NatBaseType TS)
-  | .EXPR => TypeData (NatBaseType TS)
-  | .REGION => TypeData (NatBaseType TS) × TypeData (NatBaseType TS)
+def SSAIndex.ieval (Op : Type)
+    [TypedUserSemantics Op BaseType] : SSAIndex → Type
+  | .TERMINATOR => TypeData BaseType
+  | .EXPR => TypeData BaseType
+  | .REGION => TypeData BaseType × TypeData BaseType
   | .STMT => List Var
 
-abbrev K : Type → Type := StateT ((Var → NatTypeData TS) × (Var → (NatTypeData TS × NatTypeData TS))) Option
+abbrev K : Type → Type := StateT ((Var → TypeData BaseType) × (Var → (TypeData  BaseType × TypeData BaseType))) Option
 
-def getVars : K TS (Var → NatTypeData TS) :=
+-- Lean gets very picky here and wants to get all instances passed explicit to be sure they're the same
+def getVars  : @K BaseType instDecidableEqBaseType instBaseTypeClass (Var → @TypeData BaseType instDecidableEqBaseType instBaseTypeClass) :=
   do return (← StateT.get).1
 
-def getVarType (v : Var) : K TS (NatTypeData TS) :=
-  do return (← getVars TS) v
+def getVarType (v : Var) : @K BaseType instDecidableEqBaseType instBaseTypeClass (TypeData BaseType) :=
+  do return (← getVars) v
 
-def updateType (v : Var) (t : NatTypeData TS) : K TS Unit := do
+def updateType (v : Var) (t : TypeData BaseType) : @K BaseType instDecidableEqBaseType instBaseTypeClass Unit := do
   StateT.modifyGet (fun s => ((), fun v' => if v' = v then t else s.1 v', s.2))
 
-def assignVar (v : Var) (t : NatTypeData TS) : K TS Unit := do
-  let k ← getVarType TS v
+def assignVar (v : Var) (t : TypeData BaseType) : @K BaseType instDecidableEqBaseType instBaseTypeClass Unit := do
+  let k ← getVarType v
   match k with
-  | .unused => updateType TS v t
+  | .unused => updateType v t
   | _ => failure
 
 /-- Does not change the state. Fails if impossible to unify or if either
 input is `unused`. TypeData is a meet semilattice with top element `any`.  -/
-def unify : (t₁ t₂ : NatTypeData TS) → K TS (NatTypeData TS)
+def unify : (t₁ t₂ : TypeData BaseType) → @K BaseType instDecidableEqBaseType instBaseTypeClass (TypeData BaseType)
   | .unused, _ => failure
   | _, .unused => failure
   | .any, k => return k
@@ -158,26 +143,26 @@ def unify : (t₁ t₂ : NatTypeData TS) → K TS (NatTypeData TS)
   | .unit, .unit => return .unit
   | _, _ => failure
 
-def unifyVar (v : Var) (t : NatTypeData TS) : K TS (NatTypeData TS) := do
-  let k ← getVarType TS v
-  let k' ← unify TS k t
-  updateType TS v k'
+def unifyVar (v : Var) (t : TypeData BaseType) : @K BaseType instDecidableEqBaseType instBaseTypeClass (TypeData BaseType) := do
+  let k ← getVarType v
+  let k' ← unify k t
+  updateType v k'
   return k'
 
-def unifyRVar (v : Var) (dom : NatTypeData TS) (cod : NatTypeData TS) : K TS (NatTypeData TS × NatTypeData TS) := do
+def unifyRVar (v : Var) (dom : TypeData BaseType) (cod : TypeData BaseType) : @K BaseType instDecidableEqBaseType instBaseTypeClass (TypeData  BaseType × TypeData BaseType) := do
   let s ← StateT.get
-  let dom' ← unify TS dom (s.2 v).1
-  let cod' ← unify TS cod (s.2 v).2
+  let dom' ← unify dom (s.2 v).1
+  let cod' ← unify cod (s.2 v).2
   return (dom', cod')
 
 @[simp]
-def assignAny (t : Var → NatTypeData TS) (v : Var) : K TS Unit :=
+def assignAny (t : Var → TypeData BaseType) (v : Var) : @K BaseType instDecidableEqBaseType instBaseTypeClass Unit :=
   match t v with
-  | .unused => assignVar TS v .any
+  | .unused => assignVar v .any
   | _ => failure
 
-def unassignVars (l : List Var) : K TS Unit := do
-  l.forM (fun v => updateType TS v .unused)
+def unassignVars (l : List Var) : @K BaseType instDecidableEqBaseType instBaseTypeClass Unit := do
+  l.forM (fun v => updateType v .unused)
 
 /-- Given an expected type, tries to infer the type of an expression.
 The state consists of the expected type of any free variables, and this state is
@@ -192,21 +177,23 @@ Return the type of the returned variable. Fails when bound variable is not `unus
 variables, only free variables.
 * If `REGION` then as for `EXPR`  -/
 -- @chris: the type signature should be `SSA Op i → K (Context BaseType)`?
-def inferType {Op : Type} (TS : TypeSemantics) [TypedUserSemantics Op TS] :
-    {i : SSAIndex} → SSA Op i → (i.ieval Op TS) → K TS (i.ieval Op TS)
+def inferType {Op : Type} [ instUS : TypedUserSemantics Op BaseType] :
+    {i : SSAIndex} → SSA Op i →
+    (@SSAIndex.ieval BaseType instDecidableEqBaseType instBaseTypeClass Op instUS i)
+    → @K BaseType instDecidableEqBaseType instBaseTypeClass (@SSAIndex.ieval BaseType instDecidableEqBaseType instBaseTypeClass Op instUS i)
   | _,  .assign lhs rhs rest, _ => do
-    let k ← inferType TS rhs (← getVarType TS lhs)
-    assignVar TS lhs k
-    let l ← inferType TS rest []
+    let k ← inferType rhs (← getVarType lhs)
+    assignVar lhs k
+    let l ← inferType rest []
     return lhs :: l
   | _, .nop, _ => return []
   | _, .ret s v, k => do
-    let l ← inferType TS s []
-    let k' ← unifyVar TS v k
-    unassignVars TS l
+    let l ← inferType s []
+    let k' ← unifyVar v k
+    unassignVars l
     return k'
   | _, .pair fst snd, k => do
-    unify TS (.pair (← getVarType TS fst) (← getVarType TS snd)) k
+    unify (.pair (← getVarType fst) (← getVarType snd)) k
     /-
     match k with
     | .any => return (.pair (← getVarType fst) (← getVarType snd))
@@ -229,19 +216,20 @@ def inferType {Op : Type} (TS : TypeSemantics) [TypedUserSemantics Op TS] :
     | _ => failure
     -/
   | _,  .op o arg r, _ => do
-    let _ ← unifyVar arg (TypedUserSemantics.argKind TS o)
-    let _ ← inferType TS r
-      (TypedUserSemantics.rgnDom TS o, TypedUserSemantics.rgnCod TS o)
-    return (TypedUserSemantics.outKind TS o).toTypeData
+    --let _ ← unifyVar arg (TypedUserSemantics.argKind o)
+    --let _ ← inferType r
+    --  (TypedUserSemantics.rgnDom o, TypedUserSemantics.rgnCod o)
+    --return (TypedUserSemantics.outKind o).toTypeData
+    sorry
   | _, .var v, k => unifyVar v k
   | _, .rgnvar v, k => unifyRVar v k.1 k.2
   | _, .rgn0, k => do
-    let _ ← unify k.1 Kind.unit.toTypeData
-    let _ ← unify k.2 Kind.unit.toTypeData
-    return (Kind.unit.toTypeData, Kind.unit.toTypeData)
+    let _ ← unify k.1 UserType.unit.toTypeData
+    let _ ← unify k.2 UserType.unit.toTypeData
+    return (UserType.unit.toTypeData, UserType.unit.toTypeData)
   | _, .rgn arg body, k => do
     let dom ← unifyVar arg k.1
-    let cod ← inferType TS body k.2
+    let cod ← inferType body k.2
     unassignVars [arg]
     return (dom, cod)
 
@@ -367,20 +355,20 @@ def inferType {Op : Type} (TS : TypeSemantics) [TypedUserSemantics Op TS] :
 --   | .EXPR => Σ k : Kind, TypeSemantics.toType k
 
 @[simp]
-def SSAIndex.teval (Op : Type)  (TS : TypeSemantics)
-    [TypedUserSemantics Op TS] (sem : Var → TypeData) :
+def SSAIndex.teval (Op : Type)
+    [TypedUserSemantics Op BaseType] (sem : Var → TypeData BaseType) :
     SSAIndex → Type
   | .TERMINATOR => Var
-  | .EXPR => Σ (t : TypeData) (_ : Var → TypeData),
-      ((∀ v, (sem v).toType TS) → t.toType TS)
-  | .REGION => Σ (dom cod : TypeData), ((∀ v, (sem v).toType TS) → dom.toType TS → cod.toType TS)
-  | .STMT => (∀ v, (sem v).toType TS) → Σ (s : Var → TypeData),  (∀ v, (s v).toType TS)
+  | .EXPR => Σ (t : TypeData BaseType) (_ : Var → TypeData BaseType),
+      ((∀ v, (sem v).toType) → t.toType)
+  | .REGION => Σ (dom cod : TypeData BaseType), ((∀ v, (sem v).toType) → dom.toType → cod.toType)
+  | .STMT => (∀ v, (sem v).toType) → Σ (s : Var → TypeData BaseType),  (∀ v, (s v).toType)
 
 open TypeData
 
-def SSA.teval {Op : Type} (TS : TypeSemantics) [TypedUserSemantics Op TS]
-    [DecidableEq Kind] : (sem : Var → TypeData) → {k : SSAIndex} → SSA Op k →
-    k.teval Op TS sem
+def SSA.teval {Op : Type} [TypedUserSemantics Op BaseType]
+    : (sem : Var → TypeData BaseType) → {k : SSAIndex} → SSA Op k →
+    k.teval Op sem
 | sem, _, .assign lhs rhs rest => fun s => sorry
   -- let ⟨sem₁, rest⟩ := SSA.teval (Kind := Kind) sem rest s
   -- let ⟨t, sem₂, f⟩ := SSA.teval (Kind := Kind) sem rhs
@@ -399,3 +387,28 @@ def SSA.teval {Op : Type} (TS : TypeSemantics) [TypedUserSemantics Op TS]
 | _, _, .rgnvar v => _
 | _, _, .rgn0 => _
 | _, _, .rgn arg body => _
+
+-- We can recover the case with the TypeSemantics as an instance
+def TypeSemantics : Type 1 :=
+  ℕ → Type
+
+inductive NatBaseType (TS : TypeSemantics) : Type
+  | ofNat : ℕ → NatBaseType TS
+deriving DecidableEq
+
+instance : BaseTypeClass (NatBaseType TS) where toType :=
+  fun n => match n with
+    | .ofNat m => TS m
+
+variable {TS : TypeSemantics}
+abbrev NatUserType := UserType (NatBaseType TS)
+abbrev NatTypeData := TypeData (NatBaseType TS)
+
+@[simp]
+def NatTypeData.toType (TS : TypeSemantics) : @NatTypeData TS → Type
+  | TypeData.some (.ofNat k) => TS k
+  | TypeData.unit => Unit
+  | TypeData.pair t₁ t₂ => (NatTypeData.toType TS t₁) × (NatTypeData.toType TS t₂)
+  | TypeData.triple t₁ t₂ t₃ => (NatTypeData.toType TS t₁) × (NatTypeData.toType TS t₂) × (NatTypeData.toType TS t₃)
+  | TypeData.any => Σ (k : NatUserType), @UserType.toType (@NatBaseType TS) instDecidableEqNatBaseType (@instBaseTypeClassNatBaseTypeInstDecidableEqNatBaseType TS) k
+  | TypeData.unused => Unit

--- a/SSA/WellTypedFramework.lean
+++ b/SSA/WellTypedFramework.lean
@@ -5,8 +5,11 @@ import Mathlib.Data.Option.Basic
 Typeclass for a `baseType` which is a godel code of 
 Lean types.
 -/
-class Godel (BaseType : Type)  : Type 1 where
-  toType : BaseType → Type
+class Godel (β : Type)  : Type 1 where
+  toType : β → Type
+open Godel /- make toType publically visible in module. -/
+
+notation "⟦" x "⟧" => Godel.toType x
 
 instance : Godel Unit where toType := fun _ => Unit
 
@@ -18,110 +21,113 @@ inductive UserType (T : Type) : Type where
 
 namespace UserType
 
-instance: Inhabited (UserType BaseType) where default := UserType.unit
+instance: Inhabited (UserType β) where default := UserType.unit
 
-def toType [Godel BaseType] : UserType BaseType → Type
-  | .base t => Godel.toType t
+def toType [Godel β] : UserType β → Type
+  | .base t =>  ⟦t⟧
   | .pair k₁ k₂ => (toType k₁) × (toType k₂)
   | .triple k₁ k₂ k₃ => toType k₁ × toType k₂ × toType k₃
   | .unit => Unit
 
-def mkPair {BaseType : Type} [Godel BaseType] {k₁ k₂ : UserType BaseType}: toType k₁ → toType k₂ → toType (.pair k₁ k₂)
+instance [Godel β] : Godel (UserType β) where 
+  toType := toType 
+
+def mkPair [Godel β] {k₁ k₂ : UserType β}: ⟦k₁⟧ → ⟦k₂⟧ → ⟦k₁.pair k₂⟧
   | k₁, k₂ => (k₁, k₂)
 
-def mkTriple {BaseType : Type} [Godel BaseType] {k₁ k₂ k₃ : UserType BaseType}: toType k₁ → toType k₂ → toType k₃ → toType (.triple k₁ k₂ k₃)
+def mkTriple [Godel β] {k₁ k₂ k₃ : UserType β}: ⟦k₁⟧ → ⟦k₂⟧ → ⟦k₃⟧ → ⟦k₁.triple k₂ k₃⟧
   | k₁, k₂, k₃ => (k₁, k₂, k₃)
 
-def fstPair {BaseType : Type} [Godel BaseType] {k₁ k₂ : UserType BaseType} : toType (.pair k₁ k₂) → toType k₁
+def fstPair [Godel β] {k₁ k₂ : UserType β} : ⟦k₁.pair k₂⟧ → ⟦k₁⟧
   | (k₁, _) => k₁
 
-def sndPair {BaseType : Type} [Godel BaseType] {k₁ k₂ : UserType BaseType} : toType (.pair k₁ k₂) → toType k₂
+def sndPair [Godel β] {k₁ k₂ : UserType β} : ⟦k₁.pair k₂⟧ → ⟦k₂⟧
   | (_, k₂) => k₂
 
-def fstTriple {BaseType : Type} [Godel BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₁
+def fstTriple [Godel β] {k₁ k₂ k₃ : UserType β} : ⟦k₁.triple k₂ k₃⟧ → ⟦k₁⟧
   | (k₁, _, _) => k₁
 
-def sndTriple {BaseType : Type} [Godel BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₂
+def sndTriple [Godel β] {k₁ k₂ k₃ : UserType β} : ⟦k₁.triple k₂ k₃⟧ → ⟦k₂⟧
   | (_, k₂, _) => k₂
 
-def trdTriple {BaseType : Type} [Godel BaseType] {k₁ k₂ k₃ : UserType BaseType} : toType (.triple k₁ k₂ k₃) → toType k₃
+def trdTriple [Godel β] {k₁ k₂ k₃ : UserType β} : ⟦k₁.triple k₂ k₃⟧ → ⟦k₃⟧
   | (_, _, k₃) => k₃
 
 end UserType
 
 
-structure UserData {BaseType : Type} [Godel BaseType] where
-  type : UserType BaseType
-  value : type.toType
+structure UserData [Godel β] where
+  type : UserType β
+  value : toType type
 
 
--- @goens: I suggest removing [DecidableEq ...] [Godel ...]
--- We do not keep typeclass constraints on definitions, only on use sites.
--- See the Haskell rationale: 
-inductive  TypeData (BaseType : Type) : Type
-  | some : BaseType → TypeData BaseType
-  | unit : TypeData BaseType
-  | pair : TypeData BaseType → TypeData BaseType → TypeData BaseType
-  | triple : TypeData BaseType → TypeData BaseType → TypeData BaseType → TypeData BaseType
-  | any : TypeData BaseType
-  | unused : TypeData BaseType -- Or bound
+inductive  TypeData (β : Type) : Type
+  | some : β → TypeData β
+  | unit : TypeData β
+  | pair : TypeData β → TypeData β → TypeData β
+  | triple : TypeData β → TypeData β → TypeData β → TypeData β
+  | any : TypeData β
+  | unused : TypeData β -- Or bound
 
 @[coe]
-def UserType.toTypeData [Godel BaseType] : UserType BaseType → TypeData BaseType
+def UserType.toTypeData [Godel β] : UserType β → TypeData β
   | UserType.base t => TypeData.some t
   | UserType.unit => TypeData.unit
   | UserType.pair k₁ k₂ => TypeData.pair (UserType.toTypeData k₁) (UserType.toTypeData k₂)
   | UserType.triple k₁ k₂ k₃ => TypeData.triple (UserType.toTypeData k₁) (UserType.toTypeData k₂)
     (UserType.toTypeData k₃)
 
-variable {BaseType : Type} [instDecidableEqBaseType : DecidableEq BaseType] [instGodel : Godel BaseType]
-instance : Coe (UserType BaseType) (TypeData BaseType) := ⟨UserType.toTypeData⟩
+variable {β : Type} [instDecidableEqBaseType : DecidableEq β] [instGodel : Godel β]
+instance : Coe (UserType β) (TypeData β) := ⟨UserType.toTypeData⟩
 
-class TypedUserSemantics (Op : Type) (BaseType : Type) [Godel BaseType] where
-  argKind : Op → UserType BaseType
-  rgnDom : Op → UserType BaseType
-  rgnCod : Op → UserType BaseType
-  outKind : Op → UserType BaseType
-  eval : ∀ (o : Op), (argKind o).toType → ((rgnDom o).toType →
-    (rgnCod o).toType) → (outKind o).toType
+class TypedUserSemantics (Op : Type) (β : Type) [Godel β] where
+  argKind : Op → UserType β
+  rgnDom : Op → UserType β
+  rgnCod : Op → UserType β
+  outKind : Op → UserType β
+  eval : ∀ (o : Op), toType (argKind o)  → (toType (rgnDom o) →
+    toType (rgnCod o)) → toType (outKind o)
 
 @[simp]
-def TypeData.toType : TypeData BaseType → Type
+def TypeData.toType : TypeData β → Type
   | TypeData.some t => Godel.toType t
   | TypeData.unit => Unit
   | TypeData.pair t₁ t₂ => (TypeData.toType  t₁) × (TypeData.toType t₂)
   | TypeData.triple t₁ t₂ t₃ => (TypeData.toType t₁) × (TypeData.toType t₂) × (TypeData.toType t₃)
-  | TypeData.any => Σ (k : UserType BaseType), UserType.toType k
+  | TypeData.any => Σ (k : UserType β), ⟦k⟧
   | TypeData.unused => Unit
 
-theorem TypeDataToTypeEqUserTypeToType (a : UserType BaseType) : a.toType = TypeData.toType a.toTypeData :=
+instance : Godel (TypeData β) where 
+  toType := TypeData.toType
+
+theorem TypeDataToTypeEqUserTypeToType (a : UserType β) : 
+  toType a = TypeData.toType a.toTypeData :=
   by
-    induction a <;> (try rfl)
-    case pair k₁ k₂ ih₁ ih₂ => simp [TypeData.toType, UserType.toType, ih₁, ih₂]
-    case triple k₁ k₂ k₃ ih₁ ih₂ ih₃ => simp [TypeData.toType, UserType.toType, ih₁, ih₂, ih₃]
+    induction a <;> 
+      (simp [Godel.toType, TypeData.toType, UserType.toType] at * <;> aesop)
 
 
 @[simp]
-def SSAIndex.ieval (Op : Type) (BaseType : Type) : SSAIndex → Type
-  | .TERMINATOR => TypeData BaseType
-  | .EXPR => TypeData BaseType
-  | .REGION => TypeData BaseType × TypeData BaseType
+def SSAIndex.ieval (Op : Type) (β : Type) : SSAIndex → Type
+  | .TERMINATOR => TypeData β
+  | .EXPR => TypeData β
+  | .REGION => TypeData β × TypeData β
   | .STMT => List Var
 
-abbrev K (BaseType : Type)  
-  : Type → Type := StateT ((Var → TypeData BaseType) × (Var → (TypeData  BaseType × TypeData BaseType))) Option
+abbrev K (β : Type)  
+  : Type → Type := StateT ((Var → TypeData β) × (Var → (TypeData  β × TypeData β))) Option
 
 -- Lean gets very picky here and wants to get all instances passed explicit to be sure they're the same
-def getVars : K BaseType (Var → TypeData BaseType) :=
+def getVars : K β (Var → TypeData β) :=
   do return (← StateT.get).1
 
-def getVarType (v : Var) : K BaseType (TypeData BaseType) :=
+def getVarType (v : Var) : K β (TypeData β) :=
   do return (← getVars) v
 
-def updateType (v : Var) (t : TypeData BaseType) : K BaseType Unit := do
+def updateType (v : Var) (t : TypeData β) : K β Unit := do
   StateT.modifyGet (fun s => ((), fun v' => if v' = v then t else s.1 v', s.2))
 
-def assignVar (v : Var) (t : TypeData BaseType) : K BaseType Unit := do
+def assignVar (v : Var) (t : TypeData β) : K β Unit := do
   let k ← getVarType v
   match k with
   | .unused => updateType v t
@@ -129,7 +135,7 @@ def assignVar (v : Var) (t : TypeData BaseType) : K BaseType Unit := do
 
 /-- Does not change the state. Fails if impossible to unify or if either
 input is `unused`. TypeData is a meet semilattice with top element `any`.  -/
-def unify : (t₁ t₂ : TypeData BaseType) → K BaseType (TypeData BaseType)
+def unify : (t₁ t₂ : TypeData β) → K β (TypeData β)
   | .unused, _ => failure
   | _, .unused => failure
   | .any, k => return k
@@ -150,25 +156,25 @@ def unify : (t₁ t₂ : TypeData BaseType) → K BaseType (TypeData BaseType)
   | .unit, .unit => return .unit
   | _, _ => failure
 
-def unifyVar (v : Var) (t : TypeData BaseType) : K BaseType  (TypeData BaseType) := do
+def unifyVar (v : Var) (t : TypeData β) : K β  (TypeData β) := do
   let k ← getVarType v
   let k' ← unify k t
   updateType v k'
   return k'
 
-def unifyRVar (v : Var) (dom : TypeData BaseType) (cod : TypeData BaseType) : K BaseType (TypeData  BaseType × TypeData BaseType) := do
+def unifyRVar (v : Var) (dom : TypeData β) (cod : TypeData β) : K β (TypeData  β × TypeData β) := do
   let s ← StateT.get
   let dom' ← unify dom (s.2 v).1
   let cod' ← unify cod (s.2 v).2
   return (dom', cod')
 
 @[simp]
-def assignAny (t : Var → TypeData BaseType) (v : Var) : K BaseType Unit :=
+def assignAny (t : Var → TypeData β) (v : Var) : K β Unit :=
   match t v with
   | .unused => assignVar v .any
   | _ => failure
 
-def unassignVars (l : List Var) : K BaseType Unit := do
+def unassignVars (l : List Var) : K β Unit := do
   l.forM (fun v => updateType v .unused)
 
 /-- Given an expected type, tries to infer the type of an expression.
@@ -183,11 +189,11 @@ Return the type of the returned variable. Fails when bound variable is not `unus
 * If `EXPR`, then return type of expression, and do not change the type of bound
 variables, only free variables.
 * If `REGION` then as for `EXPR`  -/
--- @chris: the type signature should be `SSA Op i → K (Context BaseType)`?
-def inferType {Op : Type}  [TUS : TypedUserSemantics Op BaseType] :
+-- @chris: the type signature should be `SSA Op i → K (Context β)`?
+def inferType {Op : Type}  [TUS : TypedUserSemantics Op β] :
     {i : SSAIndex} → SSA Op i →
-    (i.ieval Op BaseType)
-    → K BaseType (i.ieval Op BaseType)
+    (i.ieval Op β)
+    → K β (i.ieval Op β)
   | _,  .assign lhs rhs rest, _ => do
     let k ← inferType rhs (← getVarType lhs)
     assignVar lhs k
@@ -222,7 +228,7 @@ def inferType {Op : Type}  [TUS : TypedUserSemantics Op BaseType] :
     return (dom, cod)
 
 -- @chris: TODO: implement `eval`:
---   `SSA Op i → Environment (Option Context BaseType) → Option i.eval` or some such.
+--   `SSA Op i → Environment (Option Context β) → Option i.eval` or some such.
 
 -- @[simp]
 -- def TypeData.inf {Kind : Type} [DecidableEq Kind] :
@@ -344,18 +350,18 @@ def inferType {Op : Type}  [TUS : TypedUserSemantics Op BaseType] :
 
 @[simp]
 def SSAIndex.teval (Op : Type)
-    [TypedUserSemantics Op BaseType] (sem : Var → TypeData BaseType) :
+    [TypedUserSemantics Op β] (sem : Var → TypeData β) :
     SSAIndex → Type
   | .TERMINATOR => Var
-  | .EXPR => Σ (t : TypeData BaseType) (_ : Var → TypeData BaseType),
+  | .EXPR => Σ (t : TypeData β) (_ : Var → TypeData β),
       ((∀ v, (sem v).toType) → t.toType)
-  | .REGION => Σ (dom cod : TypeData BaseType), ((∀ v, (sem v).toType) → dom.toType → cod.toType)
-  | .STMT => (∀ v, (sem v).toType) → Σ (s : Var → TypeData BaseType),  (∀ v, (s v).toType)
+  | .REGION => Σ (dom cod : TypeData β), ((∀ v, (sem v).toType) → dom.toType → cod.toType)
+  | .STMT => (∀ v, (sem v).toType) → Σ (s : Var → TypeData β),  (∀ v, (s v).toType)
 
 open TypeData
 
-def SSA.teval {Op : Type} [TypedUserSemantics Op BaseType]
-    : (sem : Var → TypeData BaseType) → {k : SSAIndex} → SSA Op k →
+def SSA.teval {Op : Type} [TypedUserSemantics Op β]
+    : (sem : Var → TypeData β) → {k : SSAIndex} → SSA Op k →
     k.teval Op sem
 | sem, _, .assign lhs rhs rest => fun s => sorry
   -- let ⟨sem₁, rest⟩ := SSA.teval (Kind := Kind) sem rest s


### PR DESCRIPTION
I translated `Kind`s into parametric `UserType` inductives as we discussed; Lean gets pretty picky about which instance you're talking about, even with `variable`s, so the code at points becomes more messy, but in principle we should get the same just parametric on this `BaseType` with a typeclass that says we can translate to a Lean `Type`

This essentially competes with the `TypeSemantics` of Chris, where we encode the user types concretely as `Nat`s. With the instances we have in the end we could translate everything into these semantics only "under the hood".

There's an issue remaining where I couldn't figure out what was happening in the `op` case of `inferType` and sorried it now. If we agree that this approach makes sense, we can try and figure out what happened here.