### PR TITLE
Add trivial test case to better understand tactic behavior

### DIFF
--- a/SSA/Examples/InstCombinePeepholeRewrites.lean
+++ b/SSA/Examples/InstCombinePeepholeRewrites.lean
@@ -78,3 +78,59 @@ theorem InstCombineShift279 : ∀ w : Width, ∀ C : BitVector w,
       simp only [dite_true]
       congr
       rw [InstCombineShift279_base]
+
+
+theorem InstCombineTrivial: ∀ w : Width, ∀ C : BitVector w,
+  let minus_one : BitVector w := (-1).toBitVector
+  let Γ : Context UserType := List.toAList [⟨42, .unit⟩]
+  ∀ (e : EnvC Γ),  -- for metavariable in typeclass
+  --@SSA.teval BaseType instDecidableEqBaseType instGoedelBaseType SSAIndex.REGION Op TUS
+  SSA.teval e.toEnvU [dsl_region| dsl_rgn %v0  =>
+    %v42 := unit: ;
+    %v1 := op: const C %v42
+    dsl_ret %v1] (SSA.UserType.base (BaseType.bitvec w))
+    (SSA.UserType.base (BaseType.bitvec w)) =
+  SSA.teval e.toEnvU [dsl_region| dsl_rgn %v0 =>
+    %v42 := unit: ;
+    %v43 := unit: ;
+    %v44 := unit: ;
+    %v45 := unit: ;
+    %v46 := unit: ;
+    %v47 := unit: ;
+    %v48 := unit: ;
+    %v49 := unit: ;
+    %v1 := op: const minus_one %v42
+    dsl_ret %v1] (SSA.UserType.base (BaseType.bitvec w))
+    (SSA.UserType.base (BaseType.bitvec w)) := by
+      intros w C minus_one Γ e
+      funext x
+      simp only [SSA.teval]
+      simp only [Function.comp]
+      simp only [id.def]
+      simp only [SSA.teval]
+      simp only [EnvU.set]
+      simp only [if_false]
+      simp only [TypedUserSemantics.outUserType]
+      simp only [TypedUserSemantics.argUserType]
+      simp only [TypedUserSemantics.rgnDom]
+      simp only [TypedUserSemantics.rgnCod]
+      simp only [TypedUserSemantics.eval]
+      simp only [outUserType]
+      simp only [eval]
+      simp only [if_true]
+      simp only [argUserType]
+      simp only [Option.some_eq_pure]
+      simp only [EnvC.toEnvU]
+      simp only [uncurry]
+      simp only [pure_bind]
+      simp only [if_false]
+      simp only [BitVector.width]
+      simp only [dite_true]
+      simp only [pure_bind]
+      simp only [if_true]
+      simp only [pure_bind]
+      simp only [dite_true]
+
+      congr
+      rfl
+


### PR DESCRIPTION
At the start of line 88, I get in the proof state:

```
            (SSA.assign 42 SSA.unit
              (SSA.assign 43 SSA.unit
                (SSA.assign 44 SSA.unit
                  (SSA.assign 45 SSA.unit
                    (SSA.assign 46 SSA.unit
                      (SSA.assign 47 SSA.unit
                        (SSA.assign 48 SSA.unit
                          (SSA.assign 49 SSA.unit
                            (SSA.assign 1 (SSA.op (Op.const (Int.toBitVector (-1))) 42 SSA.rgn0) SSA.nop)))))))))
```

which after `simp only [SSA.teval]` expands to:

```
         do
          let __do_lift ← pure { fst := UserType.unit, snd := () }
          let __do_lift_1 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_2 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_3 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_4 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_5 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_6 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_7 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_8 ←
            do
             let __discr ←
                EnvU.set
                    (EnvU.set
                      (EnvU.set
                        (EnvU.set
                          (EnvU.set
                            (EnvU.set
                              (EnvU.set
                                (EnvU.set
                                  (EnvU.set (EnvC.toEnvU e) 0 { fst := UserType.base (BaseType.bitvec w), snd := x }) 42
                                  __do_lift)
                                43 __do_lift_1)
                              44 __do_lift_2)
                            45 __do_lift_3)
                          46 __do_lift_4)
                        47 __do_lift_5)
                      48 __do_lift_6)
                    49 __do_lift_7 42
              match __discr with
```

which after `simp only [EnvU.set]` folds to:

```
        do
          let __do_lift ← pure { fst := UserType.unit, snd := () }
          let __do_lift_1 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_2 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_3 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_4 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_5 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_6 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_7 ← pure { fst := UserType.unit, snd := () }
          let __do_lift_8 ←
            do
              let __discr ←
                if False then some __do_lift_7
                  else
                    if False then some __do_lift_6
                    else
                      if False then some __do_lift_5
                      else
                        if False then some __do_lift_4
                        else
                          if False then some __do_lift_3
                          else
                            if False then some __do_lift_2
                            else
                              if False then some __do_lift_1
                              else
                                if True then some __do_lift
                                else
                                  if False then some { fst := UserType.base (BaseType.bitvec w), snd := x }
                                  else EnvC.toEnvU e 42
```

There seems to be some quadratic behaviour. I wonder if we can avoid the `if False` cases in the first place.
