### PR TITLE
Analyse the performance of the safe tactic

### DIFF
--- a/SSA/Examples/InstCombinePeepholeRewrites.lean
+++ b/SSA/Examples/InstCombinePeepholeRewrites.lean
@@ -77,4 +77,5 @@ theorem InstCombineShift279 : ∀ w : Width, ∀ C : BitVector w,
       simp only [pure_bind]
       simp only [dite_true]
       congr
+      save
       rw [InstCombineShift279_base]


### PR DESCRIPTION
I added the save tactic at the end of a long list of simp calls:

```
    (SSA.UserType.base (BaseType.bitvec w)) := by
      intros w C minus_one Γ e
      funext x
      simp only [SSA.teval]
      simp only [Function.comp]
      simp only [id.def]
      simp only [SSA.teval]
      simp only [EnvU.set]
      simp only [if_false]
      simp only [if_true]
      simp only [TypedUserSemantics.outUserType]
      simp only [TypedUserSemantics.argUserType]
      simp only [TypedUserSemantics.rgnDom]
      simp only [TypedUserSemantics.rgnCod]
      simp only [TypedUserSemantics.eval]
      simp only [outUserType]
      simp only [eval]
      simp only [if_true]
      simp only [argUserType]
      simp only [Option.some_eq_pure]
      simp only [EnvC.toEnvU]
      simp only [uncurry]
      simp only [Option.elim]
      simp only [BitVector.width]
      simp only [pure_bind]
      simp only [dite_true]
      simp only [pure_bind]
      simp only [dite_true]
      simp only [pure_bind]
      simp only [dite_true]
      simp only [pure_bind]
      simp only [if_true]
      simp only [pure_bind]
      simp only [dite_true]
      congr
      rw [InstCombineShift279_base]
```

However, it seems to only reduce the recompilation/checking time from 16 sec to 13 sec. I wonder why this is.