### PR TITLE
accelerate lake build

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,7 +2,6 @@ import Lake
 open Lake DSL
 
 package «SSA» where
-  precompileModules := true
 
 @[default_target]
 lean_lib SSA {

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-05-18
+leanprover/lean4:nightly-2023-05-16


### PR DESCRIPTION
- use the same lean version between our repo and mathlib
- do not precompile modules (it is not yet clear if this buys us anything)