### PR TITLE
Update mathlib to Jun 8 2023

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,35 +2,17 @@
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
-   {"url": "https://github.com/xubaiw/CMark.lean",
+   {"url": "https://github.com/EdAyers/ProofWidgets4",
     "subDir?": null,
-    "rev": "2cc7cdeef67184f84db6731450e4c2b258c28fe8",
-    "name": "CMark",
-    "inputRev?": "main"}},
-  {"git":
-   {"url": "https://github.com/leanprover/lake",
-    "subDir?": null,
-    "rev": "257fc59a6464f5732a4f49e7dda0fc37475819fb",
-    "name": "lake",
-    "inputRev?": "master"}},
-  {"git":
-   {"url": "https://github.com/leanprover/doc-gen4",
-    "subDir?": null,
-    "rev": "e888e9cc383f838ef8f519e6941e32fe5c48df1b",
-    "name": "doc-gen4",
-    "inputRev?": "e888e9c"}},
-  {"git":
-   {"url": "https://github.com/mhuisi/lean4-cli",
-    "subDir?": null,
-    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
-    "name": "Cli",
-    "inputRev?": "nightly"}},
+    "rev": "3b157dc3f6162615de001a8ebe7e01d629c97448",
+    "name": "proofwidgets",
+    "inputRev?": "v0.0.10"}},
   {"git":
    {"url": "https://github.com/leanprover-community/mathlib4",
     "subDir?": null,
-    "rev": "968d650c1517a7a6859d4cd126b61558cdf80b66",
+    "rev": "4d3d2de8df93350f8e825deb31287cbbdfd4c8d0",
     "name": "mathlib",
-    "inputRev?": "968d650"}},
+    "inputRev?": "4d3d2de"}},
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
@@ -40,24 +22,12 @@
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "409f3b050034337664d21e41fe1cc1bf7f5daec0",
+    "rev": "ca73109cc40837bc61df8024c9016da4b4f99d4c",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
-   {"url": "https://github.com/hargonix/LeanInk",
-    "subDir?": null,
-    "rev": "2447df5cc6e48eb965c3c3fba87e46d353b5e9f1",
-    "name": "leanInk",
-    "inputRev?": "doc-gen"}},
-  {"git":
-   {"url": "https://github.com/fgdorais/lean4-unicode-basic",
-    "subDir?": null,
-    "rev": "ce508dcd1fd49ba15675861aafd864572a0b8252",
-    "name": "UnicodeBasic",
-    "inputRev?": "main"}},
-  {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "3156cd5b375d1a932d590c918b7ad50e3be11947",
+    "rev": "6932c4ea52914dc6b0488944e367459ddc4d01a6",
     "name": "std",
     "inputRev?": "main"}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -34,7 +34,7 @@ lean_lib SSA {
 
 -- NOTE: this must be 'm'mathlib, as indicated from:
 --  https://github.com/leanprover-community/mathlib4#using-mathlib4-as-a-dependency
-require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "968d650"
+require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "4d3d2de"
 
 meta if get_config? env = some "dev" then -- dev is so not everyone has to build it
   require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "e888e9c"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-05-16
+leanprover/lean4:nightly-2023-05-31


### PR DESCRIPTION
This is the last change before the following commit will break some of our proofs:

```
commit e50b7a3a8ab17894562a22aa5f6bad98c7c16cf1
Author: Chris Hughes <chrishughes24@gmail.com>
Date:   Thu Jun 8 08:15:22 2023 +0000

    fix: Data/Bitvec change definition of `ofInt` to the ring homomorphism (#4525)
```