### PR TITLE
Tobiasgrosser/alive simplify theorems

### DIFF
--- a/SSA/Projects/InstCombine/ForMathlib.lean
+++ b/SSA/Projects/InstCombine/ForMathlib.lean
@@ -469,6 +469,10 @@ inductive Refinement {α : Type u} : Option α → Option α → Prop
   | bothSome {x y : α } : x = y → Refinement (some x) (some y)
   | noneAny {x? : Option α} : Refinement none x?
 
+theorem refinement_some_some {α : Type u} {x y : α} :
+  Refinement (some x) (some y) ↔ x = y :=
+  ⟨by intro h; cases h; assumption, Refinement.bothSome⟩
+
 namespace Refinement
 
 theorem Refinement.refl {α: Type u} : ∀ x : Option α, Refinement x x := by 

--- a/SSA/Projects/InstCombine/InstCombineAliveStatements.lean
+++ b/SSA/Projects/InstCombine/InstCombineAliveStatements.lean
@@ -8,36 +8,48 @@ theorem bitvec_AddSub_1043 :
           (Bitvec.ofInt w 1))
         (Bitvec.ofInt w RHS)) ⊑
     some (Bitvec.sub (Bitvec.ofInt w RHS) (Bitvec.or (Bitvec.ofInt w Z) (Bitvec.not (Bitvec.ofInt w C1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1152:
  ∀ (x y : ℤ),
   some (Bitvec.add (Bitvec.ofInt 1 x) (Bitvec.ofInt 1 y)) ⊑ some (Bitvec.xor (Bitvec.ofInt 1 x) (Bitvec.ofInt 1 y))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1156 :
  ∀ (w : ℕ) (b : ℤ),
   some (Bitvec.add (Bitvec.ofInt w b) (Bitvec.ofInt w b)) ⊑
     some (Bitvec.shl (Bitvec.ofInt w b) (Bitvec.toNat (Bitvec.ofInt w 1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1156_2 :
  ∀ (w : ℕ) (b : ℤ),
   some (Bitvec.add (Bitvec.ofInt w b) (Bitvec.ofInt w b)) ⊑
     some (Bitvec.shl (Bitvec.ofInt w b) (Bitvec.toNat (Bitvec.ofInt w 1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1156_3 :
  ∀ (w : ℕ) (b : ℤ),
   some (Bitvec.add (Bitvec.ofInt w b) (Bitvec.ofInt w b)) ⊑
     some (Bitvec.shl (Bitvec.ofInt w b) (Bitvec.toNat (Bitvec.ofInt w 1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1164 :
  ∀ (w : ℕ) (a b : ℤ),
   some (Bitvec.add (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w a)) (Bitvec.ofInt w b)) ⊑
     some (Bitvec.sub (Bitvec.ofInt w b) (Bitvec.ofInt w a))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1165 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -45,19 +57,25 @@ theorem bitvec_AddSub_1165 :
       (Bitvec.add (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w a))
         (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.add (Bitvec.ofInt w a) (Bitvec.ofInt w b)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1176 :
  ∀ (w : ℕ) (b a : ℤ),
   some (Bitvec.add (Bitvec.ofInt w a) (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.sub (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1202 :
  ∀ (w : ℕ) (x C : ℤ),
   some (Bitvec.add (Bitvec.xor (Bitvec.ofInt w x) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w C)) ⊑
     some (Bitvec.sub (Bitvec.sub (Bitvec.ofInt w C) (Bitvec.ofInt w 1)) (Bitvec.ofInt w x))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1295 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -65,7 +83,9 @@ theorem bitvec_AddSub_1295 :
       (Bitvec.add (Bitvec.and (Bitvec.ofInt w a) (Bitvec.ofInt w b))
         (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.or (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1309 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -73,7 +93,9 @@ theorem bitvec_AddSub_1309 :
       (Bitvec.add (Bitvec.and (Bitvec.ofInt w a) (Bitvec.ofInt w b))
         (Bitvec.or (Bitvec.ofInt w a) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.add (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1309_2 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -81,7 +103,9 @@ theorem bitvec_AddSub_1309_2 :
       (Bitvec.add (Bitvec.and (Bitvec.ofInt w a) (Bitvec.ofInt w b))
         (Bitvec.or (Bitvec.ofInt w a) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.add (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1309_3 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -89,60 +113,80 @@ theorem bitvec_AddSub_1309_3 :
       (Bitvec.add (Bitvec.and (Bitvec.ofInt w a) (Bitvec.ofInt w b))
         (Bitvec.or (Bitvec.ofInt w a) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.add (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1539 :
  ∀ (w : ℕ) (a x : ℤ),
   some (Bitvec.sub (Bitvec.ofInt w x) (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w a))) ⊑
     some (Bitvec.add (Bitvec.ofInt w x) (Bitvec.ofInt w a))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1539_2 :
  ∀ (w : ℕ) (x C : ℤ),
   some (Bitvec.sub (Bitvec.ofInt w x) (Bitvec.ofInt w C)) ⊑
     some (Bitvec.add (Bitvec.ofInt w x) (Bitvec.neg (Bitvec.ofInt w C)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1546 :
  ∀ (w : ℕ) (a x : ℤ),
   some (Bitvec.sub (Bitvec.ofInt w x) (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w a))) ⊑
     some (Bitvec.add (Bitvec.ofInt w x) (Bitvec.ofInt w a))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1556:
  ∀ (x y : ℤ),
   some (Bitvec.sub (Bitvec.ofInt 1 x) (Bitvec.ofInt 1 y)) ⊑ some (Bitvec.xor (Bitvec.ofInt 1 x) (Bitvec.ofInt 1 y))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1560 :
  ∀ (w : ℕ) (a : ℤ),
   some (Bitvec.sub (Bitvec.ofInt w (-1)) (Bitvec.ofInt w a)) ⊑
     some (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w (-1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1564 :
  ∀ (w : ℕ) (x C : ℤ),
   some (Bitvec.sub (Bitvec.ofInt w C) (Bitvec.xor (Bitvec.ofInt w x) (Bitvec.ofInt w (-1)))) ⊑
     some (Bitvec.add (Bitvec.ofInt w x) (Bitvec.add (Bitvec.ofInt w C) (Bitvec.ofInt w 1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1574 :
  ∀ (w : ℕ) (X C2 C : ℤ),
   some (Bitvec.sub (Bitvec.ofInt w C) (Bitvec.add (Bitvec.ofInt w X) (Bitvec.ofInt w C2))) ⊑
     some (Bitvec.sub (Bitvec.sub (Bitvec.ofInt w C) (Bitvec.ofInt w C2)) (Bitvec.ofInt w X))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1614 :
  ∀ (w : ℕ) (X Y : ℤ),
   some (Bitvec.sub (Bitvec.ofInt w X) (Bitvec.add (Bitvec.ofInt w X) (Bitvec.ofInt w Y))) ⊑
     some (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w Y))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1619 :
  ∀ (w : ℕ) (X Y : ℤ),
   some (Bitvec.sub (Bitvec.sub (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) (Bitvec.ofInt w X)) ⊑
     some (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w Y))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AddSub_1624 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -150,7 +194,9 @@ theorem bitvec_AddSub_1624 :
       (Bitvec.sub (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B))) ⊑
     some (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_135 :
  ∀ (w : ℕ) (X C1 C2 : ℤ),
@@ -158,7 +204,9 @@ theorem bitvec_AndOrXor_135 :
     some
       (Bitvec.xor (Bitvec.and (Bitvec.ofInt w X) (Bitvec.ofInt w C2))
         (Bitvec.and (Bitvec.ofInt w C1) (Bitvec.ofInt w C2)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_144 :
  ∀ (w : ℕ) (X C1 C2 : ℤ),
@@ -166,7 +214,9 @@ theorem bitvec_AndOrXor_144 :
     some
       (Bitvec.and (Bitvec.or (Bitvec.ofInt w X) (Bitvec.and (Bitvec.ofInt w C1) (Bitvec.ofInt w C2)))
         (Bitvec.ofInt w C2))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_1230__A__B___A__B :
  ∀ (w : ℕ) (notOp0 notOp1 : ℤ),
@@ -174,7 +224,9 @@ theorem bitvec_AndOrXor_1230__A__B___A__B :
       (Bitvec.and (Bitvec.xor (Bitvec.ofInt w notOp0) (Bitvec.ofInt w (-1)))
         (Bitvec.xor (Bitvec.ofInt w notOp1) (Bitvec.ofInt w (-1)))) ⊑
     some (Bitvec.xor (Bitvec.or (Bitvec.ofInt w notOp0) (Bitvec.ofInt w notOp1)) (Bitvec.ofInt w (-1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_1241_AB__AB__AB :
  ∀ (w : ℕ) (A B : ℤ),
@@ -182,7 +234,9 @@ theorem bitvec_AndOrXor_1241_AB__AB__AB :
       (Bitvec.and (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.xor (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B)) (Bitvec.ofInt w (-1)))) ⊑
     some (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_1247_AB__AB__AB :
  ∀ (w : ℕ) (A B : ℤ),
@@ -190,13 +244,17 @@ theorem bitvec_AndOrXor_1247_AB__AB__AB :
       (Bitvec.and (Bitvec.xor (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B)) (Bitvec.ofInt w (-1)))
         (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w B))) ⊑
     some (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_1253_A__AB___A__B :
  ∀ (w : ℕ) (A B : ℤ),
   some (Bitvec.and (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B)) (Bitvec.ofInt w A)) ⊑
     some (Bitvec.and (Bitvec.ofInt w A) (Bitvec.xor (Bitvec.ofInt w B) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_1280_ABA___AB :
  ∀ (w : ℕ) (A B : ℤ),
@@ -204,7 +262,9 @@ theorem bitvec_AndOrXor_1280_ABA___AB :
       (Bitvec.and (Bitvec.or (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w B))
         (Bitvec.ofInt w A)) ⊑
     some (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_1288_A__B__B__C__A___A__B__C :
  ∀ (w : ℕ) (A B C : ℤ),
@@ -214,7 +274,9 @@ theorem bitvec_AndOrXor_1288_A__B__B__C__A___A__B__C :
     some
       (Bitvec.and (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.xor (Bitvec.ofInt w C) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_1294_A__B__A__B___A__B :
  ∀ (w : ℕ) (A B : ℤ),
@@ -222,7 +284,9 @@ theorem bitvec_AndOrXor_1294_A__B__A__B___A__B :
       (Bitvec.and (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.xor (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w B))) ⊑
     some (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
  ∀ (w : ℕ) (x C1 C : ℤ),
@@ -230,7 +294,9 @@ theorem bitvec_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
     some
       (Bitvec.xor (Bitvec.or (Bitvec.ofInt w x) (Bitvec.ofInt w C))
         (Bitvec.and (Bitvec.ofInt w C1) (Bitvec.not (Bitvec.ofInt w C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2113___A__B__A___A__B :
  ∀ (w : ℕ) (A B : ℤ),
@@ -238,7 +304,9 @@ theorem bitvec_AndOrXor_2113___A__B__A___A__B :
       (Bitvec.or (Bitvec.and (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w B))
         (Bitvec.ofInt w A)) ⊑
     some (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2118___A__B__A___A__B :
  ∀ (w : ℕ) (A B : ℤ),
@@ -246,7 +314,9 @@ theorem bitvec_AndOrXor_2118___A__B__A___A__B :
       (Bitvec.or (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1)))) ⊑
     some (Bitvec.or (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2123___A__B__A__B___A__B :
  ∀ (w : ℕ) (B A : ℤ),
@@ -254,7 +324,9 @@ theorem bitvec_AndOrXor_2123___A__B__A__B___A__B :
       (Bitvec.or (Bitvec.and (Bitvec.ofInt w A) (Bitvec.xor (Bitvec.ofInt w B) (Bitvec.ofInt w (-1))))
         (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B))) ⊑
     some (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2188 :
  ∀ (w : ℕ) (D A : ℤ),
@@ -262,7 +334,9 @@ theorem bitvec_AndOrXor_2188 :
       (Bitvec.or (Bitvec.and (Bitvec.ofInt w A) (Bitvec.xor (Bitvec.ofInt w D) (Bitvec.ofInt w (-1))))
         (Bitvec.and (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w D))) ⊑
     some (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w D))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2231__A__B__B__C__A___A__B__C :
  ∀ (w : ℕ) (A B C : ℤ),
@@ -270,14 +344,18 @@ theorem bitvec_AndOrXor_2231__A__B__B__C__A___A__B__C :
       (Bitvec.or (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.xor (Bitvec.xor (Bitvec.ofInt w B) (Bitvec.ofInt w C)) (Bitvec.ofInt w A))) ⊑
     some (Bitvec.or (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B)) (Bitvec.ofInt w C))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2243__B__C__A__B___B__A__C :
  ∀ (w : ℕ) (B C A : ℤ),
   some
       (Bitvec.or (Bitvec.and (Bitvec.or (Bitvec.ofInt w B) (Bitvec.ofInt w C)) (Bitvec.ofInt w A)) (Bitvec.ofInt w B)) ⊑
     some (Bitvec.or (Bitvec.ofInt w B) (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w C)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2247__A__B__A__B :
  ∀ (w : ℕ) (A B : ℤ),
@@ -285,13 +363,17 @@ theorem bitvec_AndOrXor_2247__A__B__A__B :
       (Bitvec.or (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1)))
         (Bitvec.xor (Bitvec.ofInt w B) (Bitvec.ofInt w (-1)))) ⊑
     some (Bitvec.xor (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B)) (Bitvec.ofInt w (-1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2263 :
  ∀ (w : ℕ) (op0 B : ℤ),
   some (Bitvec.or (Bitvec.ofInt w op0) (Bitvec.xor (Bitvec.ofInt w op0) (Bitvec.ofInt w B))) ⊑
     some (Bitvec.or (Bitvec.ofInt w op0) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2264 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -299,7 +381,9 @@ theorem bitvec_AndOrXor_2264 :
       (Bitvec.or (Bitvec.ofInt w A)
         (Bitvec.xor (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w B))) ⊑
     some (Bitvec.or (Bitvec.ofInt w A) (Bitvec.xor (Bitvec.ofInt w B) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2265 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -307,7 +391,9 @@ theorem bitvec_AndOrXor_2265 :
       (Bitvec.or (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B))) ⊑
     some (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2284 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -315,7 +401,9 @@ theorem bitvec_AndOrXor_2284 :
       (Bitvec.or (Bitvec.ofInt w A)
         (Bitvec.xor (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w B)) (Bitvec.ofInt w (-1)))) ⊑
     some (Bitvec.or (Bitvec.ofInt w A) (Bitvec.xor (Bitvec.ofInt w B) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2285 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -323,7 +411,9 @@ theorem bitvec_AndOrXor_2285 :
       (Bitvec.or (Bitvec.ofInt w A)
         (Bitvec.xor (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w B)) (Bitvec.ofInt w (-1)))) ⊑
     some (Bitvec.or (Bitvec.ofInt w A) (Bitvec.xor (Bitvec.ofInt w B) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2297 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -331,13 +421,17 @@ theorem bitvec_AndOrXor_2297 :
       (Bitvec.or (Bitvec.and (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.xor (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w B))) ⊑
     some (Bitvec.xor (Bitvec.xor (Bitvec.ofInt w A) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2367 :
  ∀ (w : ℕ) (A C1 op1 : ℤ),
   some (Bitvec.or (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w C1)) (Bitvec.ofInt w op1)) ⊑
     some (Bitvec.or (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w op1)) (Bitvec.ofInt w C1))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2375 :
  ∀ (w : ℕ) (x A B C D : ℤ),
@@ -347,7 +441,9 @@ theorem bitvec_AndOrXor_2375 :
     some
       (Bitvec.select (Bitvec.ofInt 1 x) (Bitvec.or (Bitvec.ofInt w A) (Bitvec.ofInt w C))
         (Bitvec.or (Bitvec.ofInt w B) (Bitvec.ofInt w D)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2416 :
  ∀ (w : ℕ) (nx y : ℤ),
@@ -355,7 +451,9 @@ theorem bitvec_AndOrXor_2416 :
       (Bitvec.xor (Bitvec.and (Bitvec.xor (Bitvec.ofInt w nx) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w y))
         (Bitvec.ofInt w (-1))) ⊑
     some (Bitvec.or (Bitvec.ofInt w nx) (Bitvec.xor (Bitvec.ofInt w y) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2417 :
  ∀ (w : ℕ) (nx y : ℤ),
@@ -363,7 +461,9 @@ theorem bitvec_AndOrXor_2417 :
       (Bitvec.xor (Bitvec.or (Bitvec.xor (Bitvec.ofInt w nx) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w y))
         (Bitvec.ofInt w (-1))) ⊑
     some (Bitvec.and (Bitvec.ofInt w nx) (Bitvec.xor (Bitvec.ofInt w y) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2429 :
  ∀ (w : ℕ) (x y : ℤ),
@@ -371,7 +471,9 @@ theorem bitvec_AndOrXor_2429 :
     some
       (Bitvec.or (Bitvec.xor (Bitvec.ofInt w x) (Bitvec.ofInt w (-1)))
         (Bitvec.xor (Bitvec.ofInt w y) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2430 :
  ∀ (w : ℕ) (x y : ℤ),
@@ -379,7 +481,9 @@ theorem bitvec_AndOrXor_2430 :
     some
       (Bitvec.and (Bitvec.xor (Bitvec.ofInt w x) (Bitvec.ofInt w (-1)))
         (Bitvec.xor (Bitvec.ofInt w y) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2443 :
  ∀ (w : ℕ) (x y : ℤ),
@@ -387,31 +491,41 @@ theorem bitvec_AndOrXor_2443 :
       (Bitvec.xor (Bitvec.sshr (Bitvec.xor (Bitvec.ofInt w x) (Bitvec.ofInt w (-1))) (Bitvec.toNat (Bitvec.ofInt w y)))
         (Bitvec.ofInt w (-1))) ⊑
     some (Bitvec.sshr (Bitvec.ofInt w x) (Bitvec.toNat (Bitvec.ofInt w y)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2475 :
  ∀ (w : ℕ) (C x : ℤ),
   some (Bitvec.xor (Bitvec.sub (Bitvec.ofInt w C) (Bitvec.ofInt w x)) (Bitvec.ofInt w (-1))) ⊑
     some (Bitvec.add (Bitvec.ofInt w x) (Bitvec.sub (Bitvec.ofInt w (-1)) (Bitvec.ofInt w C)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2486 :
  ∀ (w : ℕ) (x C : ℤ),
   some (Bitvec.xor (Bitvec.add (Bitvec.ofInt w x) (Bitvec.ofInt w C)) (Bitvec.ofInt w (-1))) ⊑
     some (Bitvec.sub (Bitvec.sub (Bitvec.ofInt w (-1)) (Bitvec.ofInt w C)) (Bitvec.ofInt w x))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2581__BAB___A__B :
  ∀ (w : ℕ) (a op1 : ℤ),
   some (Bitvec.xor (Bitvec.or (Bitvec.ofInt w a) (Bitvec.ofInt w op1)) (Bitvec.ofInt w op1)) ⊑
     some (Bitvec.and (Bitvec.ofInt w a) (Bitvec.xor (Bitvec.ofInt w op1) (Bitvec.ofInt w (-1))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2587__BAA___B__A :
  ∀ (w : ℕ) (a op1 : ℤ),
   some (Bitvec.xor (Bitvec.and (Bitvec.ofInt w a) (Bitvec.ofInt w op1)) (Bitvec.ofInt w op1)) ⊑
     some (Bitvec.and (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w op1))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2595 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -419,7 +533,9 @@ theorem bitvec_AndOrXor_2595 :
       (Bitvec.xor (Bitvec.and (Bitvec.ofInt w a) (Bitvec.ofInt w b))
         (Bitvec.or (Bitvec.ofInt w a) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2607 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -427,7 +543,9 @@ theorem bitvec_AndOrXor_2607 :
       (Bitvec.xor (Bitvec.or (Bitvec.ofInt w a) (Bitvec.xor (Bitvec.ofInt w b) (Bitvec.ofInt w (-1))))
         (Bitvec.or (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2617 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -435,7 +553,9 @@ theorem bitvec_AndOrXor_2617 :
       (Bitvec.xor (Bitvec.and (Bitvec.ofInt w a) (Bitvec.xor (Bitvec.ofInt w b) (Bitvec.ofInt w (-1))))
         (Bitvec.and (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2627 :
  ∀ (w : ℕ) (a c b : ℤ),
@@ -445,7 +565,9 @@ theorem bitvec_AndOrXor_2627 :
     some
       (Bitvec.xor (Bitvec.and (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w (-1))) (Bitvec.ofInt w b))
         (Bitvec.ofInt w c))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2647 :
  ∀ (w : ℕ) (a b : ℤ),
@@ -453,7 +575,9 @@ theorem bitvec_AndOrXor_2647 :
       (Bitvec.xor (Bitvec.and (Bitvec.ofInt w a) (Bitvec.ofInt w b))
         (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w b))) ⊑
     some (Bitvec.or (Bitvec.ofInt w a) (Bitvec.ofInt w b))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_AndOrXor_2658 :
  ∀ (w : ℕ) (b a : ℤ),
@@ -461,18 +585,24 @@ theorem bitvec_AndOrXor_2658 :
       (Bitvec.xor (Bitvec.and (Bitvec.ofInt w a) (Bitvec.xor (Bitvec.ofInt w b) (Bitvec.ofInt w (-1))))
         (Bitvec.xor (Bitvec.ofInt w a) (Bitvec.ofInt w (-1)))) ⊑
     some (Bitvec.xor (Bitvec.and (Bitvec.ofInt w a) (Bitvec.ofInt w b)) (Bitvec.ofInt w (-1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_152 :
  ∀ (w : ℕ) (x : ℤ),
   some (Bitvec.mul (Bitvec.ofInt w x) (Bitvec.ofInt w (-1))) ⊑ some (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w x))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_160:
  ∀ (x C2 C1 : ℤ),
   some (Bitvec.mul (Bitvec.shl (Bitvec.ofInt 7 x) (Bitvec.toNat (Bitvec.ofInt 7 C2))) (Bitvec.ofInt 7 C1)) ⊑
     some (Bitvec.mul (Bitvec.ofInt 7 x) (Bitvec.shl (Bitvec.ofInt 7 C1) (Bitvec.toNat (Bitvec.ofInt 7 C2))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_229 :
  ∀ (w : ℕ) (X C1 Op1 : ℤ),
@@ -480,7 +610,9 @@ theorem bitvec_229 :
     some
       (Bitvec.add (Bitvec.mul (Bitvec.ofInt w X) (Bitvec.ofInt w Op1))
         (Bitvec.mul (Bitvec.ofInt w C1) (Bitvec.ofInt w Op1)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_239 :
  ∀ (w : ℕ) (X Y : ℤ),
@@ -488,80 +620,104 @@ theorem bitvec_239 :
       (Bitvec.mul (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w X))
         (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w Y))) ⊑
     some (Bitvec.mul (Bitvec.ofInt w X) (Bitvec.ofInt w Y))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_265 :
  ∀ (w : ℕ) (X Y : ℤ),
   (Option.bind (Bitvec.udiv? (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) fun fst =>
       some (Bitvec.mul fst (Bitvec.ofInt w Y))) ⊑
     some (Bitvec.ofInt w X)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_265_2 :
  ∀ (w : ℕ) (X Y : ℤ),
   (Option.bind (Bitvec.sdiv? (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) fun fst =>
       some (Bitvec.mul fst (Bitvec.ofInt w Y))) ⊑
     some (Bitvec.ofInt w X)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_266 :
  ∀ (w : ℕ) (X Y : ℤ),
   (Option.bind (Bitvec.udiv? (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) fun fst =>
       some (Bitvec.mul fst (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w Y)))) ⊑
     some (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w X))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_266_2 :
  ∀ (w : ℕ) (X Y : ℤ),
   (Option.bind (Bitvec.sdiv? (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) fun fst =>
       some (Bitvec.mul fst (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w Y)))) ⊑
     some (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w X))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_275:
  ∀ (X Y : ℤ),
   (Option.bind (Bitvec.udiv? (Bitvec.ofInt 5 X) (Bitvec.ofInt 5 Y)) fun fst =>
       some (Bitvec.mul fst (Bitvec.ofInt 5 Y))) ⊑
     Option.bind (Bitvec.urem? (Bitvec.ofInt 5 X) (Bitvec.ofInt 5 Y)) fun snd => some (Bitvec.sub (Bitvec.ofInt 5 X) snd)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_275_2:
  ∀ (X Y : ℤ),
   (Option.bind (Bitvec.sdiv? (Bitvec.ofInt 5 X) (Bitvec.ofInt 5 Y)) fun fst =>
       some (Bitvec.mul fst (Bitvec.ofInt 5 Y))) ⊑
     Option.bind (Bitvec.urem? (Bitvec.ofInt 5 X) (Bitvec.ofInt 5 Y)) fun snd => some (Bitvec.sub (Bitvec.ofInt 5 X) snd)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_276:
  ∀ (X Y : ℤ),
   (Option.bind (Bitvec.sdiv? (Bitvec.ofInt 5 X) (Bitvec.ofInt 5 Y)) fun fst =>
       some (Bitvec.mul fst (Bitvec.sub (Bitvec.ofInt 5 0) (Bitvec.ofInt 5 Y)))) ⊑
     Option.bind (Bitvec.urem? (Bitvec.ofInt 5 X) (Bitvec.ofInt 5 Y)) fun fst => some (Bitvec.sub fst (Bitvec.ofInt 5 X))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_276_2:
  ∀ (X Y : ℤ),
   (Option.bind (Bitvec.udiv? (Bitvec.ofInt 5 X) (Bitvec.ofInt 5 Y)) fun fst =>
       some (Bitvec.mul fst (Bitvec.sub (Bitvec.ofInt 5 0) (Bitvec.ofInt 5 Y)))) ⊑
     Option.bind (Bitvec.urem? (Bitvec.ofInt 5 X) (Bitvec.ofInt 5 Y)) fun fst => some (Bitvec.sub fst (Bitvec.ofInt 5 X))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_283:
  ∀ (X Y : ℤ),
   some (Bitvec.mul (Bitvec.ofInt 1 X) (Bitvec.ofInt 1 Y)) ⊑ some (Bitvec.and (Bitvec.ofInt 1 X) (Bitvec.ofInt 1 Y))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_290__292 :
  ∀ (w : ℕ) (Y Op1 : ℤ),
   some (Bitvec.mul (Bitvec.shl (Bitvec.ofInt w 1) (Bitvec.toNat (Bitvec.ofInt w Y))) (Bitvec.ofInt w Op1)) ⊑
     some (Bitvec.shl (Bitvec.ofInt w Op1) (Bitvec.toNat (Bitvec.ofInt w Y)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_SimplifyDivRemOfSelect :
  ∀ (w : ℕ) (c Y X : ℤ),
   Bitvec.udiv? (Bitvec.ofInt w X) (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.ofInt w Y) (Bitvec.ofInt w 0)) ⊑
     Bitvec.udiv? (Bitvec.ofInt w X) (Bitvec.ofInt w Y)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_805 :
  ∀ (w : ℕ) (X : ℤ),
@@ -571,38 +727,50 @@ theorem bitvec_805 :
         (Bitvec.fromBool
           (decide (Bitvec.toNat (Bitvec.add (Bitvec.ofInt w X) (Bitvec.ofInt w 1)) < Bitvec.toNat (Bitvec.ofInt w 3))))
         (Bitvec.ofInt w X) (Bitvec.ofInt w 0))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_820:
  ∀ (X Op1 : ℤ),
   (Option.bind (Bitvec.urem? (Bitvec.ofInt 9 X) (Bitvec.ofInt 9 Op1)) fun x =>
       Bitvec.sdiv? (Bitvec.sub (Bitvec.ofInt 9 X) x) (Bitvec.ofInt 9 Op1)) ⊑
     Bitvec.sdiv? (Bitvec.ofInt 9 X) (Bitvec.ofInt 9 Op1)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_820':
  ∀ (X Op1 : ℤ),
   (Option.bind (Bitvec.urem? (Bitvec.ofInt 9 X) (Bitvec.ofInt 9 Op1)) fun x =>
       Bitvec.udiv? (Bitvec.sub (Bitvec.ofInt 9 X) x) (Bitvec.ofInt 9 Op1)) ⊑
     Bitvec.udiv? (Bitvec.ofInt 9 X) (Bitvec.ofInt 9 Op1)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_891:
  ∀ (N x : ℤ),
   Bitvec.udiv? (Bitvec.ofInt 13 x) (Bitvec.shl (Bitvec.ofInt 13 1) (Bitvec.toNat (Bitvec.ofInt 13 N))) ⊑
     some (Bitvec.ushr (Bitvec.ofInt 13 x) (Bitvec.toNat (Bitvec.ofInt 13 N)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_891_exact:
  ∀ (N x : ℤ),
   Bitvec.udiv? (Bitvec.ofInt 13 x) (Bitvec.shl (Bitvec.ofInt 13 1) (Bitvec.toNat (Bitvec.ofInt 13 N))) ⊑
     some (Bitvec.ushr (Bitvec.ofInt 13 x) (Bitvec.toNat (Bitvec.ofInt 13 N)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_1030 :
  ∀ (w : ℕ) (X : ℤ),
   Bitvec.sdiv? (Bitvec.ofInt w X) (Bitvec.ofInt w (-1)) ⊑ some (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w X))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_485_2 :
  ∀ (w : ℕ) (x A B : ℤ),
@@ -610,7 +778,9 @@ theorem bitvec_Select_485_2 :
       (Bitvec.select (Bitvec.fromBool (decide (Bitvec.toNat (Bitvec.ofInt 32 x) < Bitvec.toNat (Bitvec.ofInt 32 0))))
         (Bitvec.ofInt w A) (Bitvec.ofInt w B)) ⊑
     some (Bitvec.ofInt w B)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_489_2 :
  ∀ (w : ℕ) (x A B : ℤ),
@@ -618,19 +788,25 @@ theorem bitvec_Select_489_2 :
       (Bitvec.select (Bitvec.fromBool (decide (Bitvec.toNat (Bitvec.ofInt 32 (-1)) < Bitvec.toNat (Bitvec.ofInt 32 x))))
         (Bitvec.ofInt w A) (Bitvec.ofInt w B)) ⊑
     some (Bitvec.ofInt w B)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_637 :
  ∀ (w : ℕ) (X C Y : ℤ),
   some (Bitvec.select (Bitvec.fromBool (Bitvec.ofInt w X == Bitvec.ofInt w C)) (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) ⊑
     some (Bitvec.select (Bitvec.fromBool (Bitvec.ofInt w X == Bitvec.ofInt w C)) (Bitvec.ofInt w C) (Bitvec.ofInt w Y))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_641 :
  ∀ (w : ℕ) (X C Y : ℤ),
   some (Bitvec.select (Bitvec.fromBool (Bitvec.ofInt w X != Bitvec.ofInt w C)) (Bitvec.ofInt w Y) (Bitvec.ofInt w X)) ⊑
     some (Bitvec.select (Bitvec.fromBool (Bitvec.ofInt w X != Bitvec.ofInt w C)) (Bitvec.ofInt w Y) (Bitvec.ofInt w C))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_699 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -649,7 +825,9 @@ theorem bitvec_Select_699 :
     some
       (Bitvec.select (Bitvec.fromBool (decide (Bitvec.toNat (Bitvec.ofInt w B) ≤ Bitvec.toNat (Bitvec.ofInt w A))))
         (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_700 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -668,7 +846,9 @@ theorem bitvec_Select_700 :
     some
       (Bitvec.select (Bitvec.fromBool (decide (Bitvec.toInt (Bitvec.ofInt w A) < Bitvec.toInt (Bitvec.ofInt w B))))
         (Bitvec.ofInt w A) (Bitvec.ofInt w B))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_704 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -685,7 +865,9 @@ theorem bitvec_Select_704 :
           (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.ofInt w A)) ⊑
     some (Bitvec.ofInt w A)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_705 :
  ∀ (w : ℕ) (A B : ℤ),
@@ -702,7 +884,9 @@ theorem bitvec_Select_705 :
           (Bitvec.ofInt w A) (Bitvec.ofInt w B))
         (Bitvec.ofInt w A)) ⊑
     some (Bitvec.ofInt w A)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_740 :
  ∀ (w : ℕ) (A : ℤ),
@@ -723,7 +907,9 @@ theorem bitvec_Select_740 :
     some
       (Bitvec.select (Bitvec.fromBool (decide (Bitvec.toInt (Bitvec.ofInt w 0) < Bitvec.toInt (Bitvec.ofInt w A))))
         (Bitvec.ofInt w A) (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w A)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_741 :
  ∀ (w : ℕ) (A : ℤ),
@@ -744,7 +930,9 @@ theorem bitvec_Select_741 :
     some
       (Bitvec.select (Bitvec.fromBool (decide (Bitvec.toInt (Bitvec.ofInt w 0) < Bitvec.toInt (Bitvec.ofInt w A))))
         (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w A)) (Bitvec.ofInt w A))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_746 :
  ∀ (w : ℕ) (A : ℤ),
@@ -765,7 +953,9 @@ theorem bitvec_Select_746 :
     some
       (Bitvec.select (Bitvec.fromBool (decide (Bitvec.toInt (Bitvec.ofInt w 0) < Bitvec.toInt (Bitvec.ofInt w A))))
         (Bitvec.ofInt w A) (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w A)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_747 :
  ∀ (w : ℕ) (A : ℤ),
@@ -786,7 +976,9 @@ theorem bitvec_Select_747 :
     some
       (Bitvec.select (Bitvec.fromBool (decide (Bitvec.toInt (Bitvec.ofInt w A) < Bitvec.toInt (Bitvec.ofInt w 0))))
         (Bitvec.ofInt w A) (Bitvec.sub (Bitvec.ofInt w 0) (Bitvec.ofInt w A)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_962 :
  ∀ (w : ℕ) (x y z c : ℤ),
@@ -794,7 +986,9 @@ theorem bitvec_Select_962 :
       (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.add (Bitvec.ofInt w x) (Bitvec.ofInt w y))
         (Bitvec.add (Bitvec.ofInt w x) (Bitvec.ofInt w z))) ⊑
     some (Bitvec.add (Bitvec.ofInt w x) (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.ofInt w y) (Bitvec.ofInt w z)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_967a:
  ∀ (x y c : ℤ),
@@ -804,7 +998,9 @@ theorem bitvec_Select_967a:
     some
       (Bitvec.add (Bitvec.ofInt 9 x)
         (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.ofInt 9 y) (Bitvec.sub (Bitvec.ofInt 9 0) (Bitvec.ofInt 9 y))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_967b:
  ∀ (x y c : ℤ),
@@ -814,7 +1010,9 @@ theorem bitvec_Select_967b:
     some
       (Bitvec.add (Bitvec.ofInt 9 x)
         (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.sub (Bitvec.ofInt 9 0) (Bitvec.ofInt 9 y)) (Bitvec.ofInt 9 y)))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_1070 :
  ∀ (w : ℕ) (c W Z Y : ℤ),
@@ -822,7 +1020,9 @@ theorem bitvec_Select_1070 :
       (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.ofInt w W) (Bitvec.ofInt w Z))
         (Bitvec.ofInt w Y)) ⊑
     some (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.ofInt w W) (Bitvec.ofInt w Y))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_1078 :
  ∀ (w : ℕ) (c W Z X : ℤ),
@@ -830,23 +1030,31 @@ theorem bitvec_Select_1078 :
       (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.ofInt w X)
         (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.ofInt w W) (Bitvec.ofInt w Z))) ⊑
     some (Bitvec.select (Bitvec.ofInt 1 c) (Bitvec.ofInt w X) (Bitvec.ofInt w Z))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_1087 :
  ∀ (w : ℕ) (val X Y : ℤ),
   some (Bitvec.select (Bitvec.xor (Bitvec.ofInt 1 val) (true ::ᵥ Vector.nil)) (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) ⊑
     some (Bitvec.select (Bitvec.ofInt 1 val) (Bitvec.ofInt w Y) (Bitvec.ofInt w X))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_1100 :
  ∀ (w : ℕ) (X Y : ℤ),
   some (Bitvec.select (true ::ᵥ Vector.nil) (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) ⊑ some (Bitvec.ofInt w X)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_Select_1105 :
  ∀ (w : ℕ) (X Y : ℤ),
   some (Bitvec.select (false ::ᵥ Vector.nil) (Bitvec.ofInt w X) (Bitvec.ofInt w Y)) ⊑ some (Bitvec.ofInt w Y)
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__239 :
  ∀ (w : ℕ) (X C : ℤ),
@@ -854,7 +1062,9 @@ theorem bitvec_InstCombineShift__239 :
       (Bitvec.ushr (Bitvec.shl (Bitvec.ofInt w X) (Bitvec.toNat (Bitvec.ofInt w C)))
         (Bitvec.toNat (Bitvec.ofInt w C))) ⊑
     some (Bitvec.and (Bitvec.ofInt w X) (Bitvec.ushr (Bitvec.ofInt w (-1)) (Bitvec.toNat (Bitvec.ofInt w C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__279 :
  ∀ (w : ℕ) (X C : ℤ),
@@ -862,13 +1072,17 @@ theorem bitvec_InstCombineShift__279 :
       (Bitvec.shl (Bitvec.ushr (Bitvec.ofInt w X) (Bitvec.toNat (Bitvec.ofInt w C)))
         (Bitvec.toNat (Bitvec.ofInt w C))) ⊑
     some (Bitvec.and (Bitvec.ofInt w X) (Bitvec.shl (Bitvec.ofInt w (-1)) (Bitvec.toNat (Bitvec.ofInt w C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__351:
  ∀ (X C1 C2 : ℤ),
   some (Bitvec.shl (Bitvec.mul (Bitvec.ofInt 7 X) (Bitvec.ofInt 7 C1)) (Bitvec.toNat (Bitvec.ofInt 7 C2))) ⊑
     some (Bitvec.mul (Bitvec.ofInt 7 X) (Bitvec.shl (Bitvec.ofInt 7 C1) (Bitvec.toNat (Bitvec.ofInt 7 C2))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__422_1:
  ∀ (X C Y : ℤ),
@@ -878,7 +1092,9 @@ theorem bitvec_InstCombineShift__422_1:
     some
       (Bitvec.and (Bitvec.add (Bitvec.shl (Bitvec.ofInt 31 Y) (Bitvec.toNat (Bitvec.ofInt 31 C))) (Bitvec.ofInt 31 X))
         (Bitvec.shl (Bitvec.ofInt 31 (-1)) (Bitvec.toNat (Bitvec.ofInt 31 C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__422_2:
  ∀ (X C Y : ℤ),
@@ -888,7 +1104,9 @@ theorem bitvec_InstCombineShift__422_2:
     some
       (Bitvec.and (Bitvec.add (Bitvec.shl (Bitvec.ofInt 31 Y) (Bitvec.toNat (Bitvec.ofInt 31 C))) (Bitvec.ofInt 31 X))
         (Bitvec.shl (Bitvec.ofInt 31 (-1)) (Bitvec.toNat (Bitvec.ofInt 31 C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__440 :
  ∀ (w : ℕ) (X C C2 Y : ℤ),
@@ -900,7 +1118,9 @@ theorem bitvec_InstCombineShift__440 :
     some
       (Bitvec.xor (Bitvec.and (Bitvec.ofInt w X) (Bitvec.shl (Bitvec.ofInt w C2) (Bitvec.toNat (Bitvec.ofInt w C))))
         (Bitvec.shl (Bitvec.ofInt w Y) (Bitvec.toNat (Bitvec.ofInt w C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__458:
  ∀ (X C Y : ℤ),
@@ -910,7 +1130,9 @@ theorem bitvec_InstCombineShift__458:
     some
       (Bitvec.and (Bitvec.sub (Bitvec.ofInt 31 X) (Bitvec.shl (Bitvec.ofInt 31 Y) (Bitvec.toNat (Bitvec.ofInt 31 C))))
         (Bitvec.shl (Bitvec.ofInt 31 (-1)) (Bitvec.toNat (Bitvec.ofInt 31 C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__476 :
  ∀ (w : ℕ) (X C C2 Y : ℤ),
@@ -922,7 +1144,9 @@ theorem bitvec_InstCombineShift__476 :
     some
       (Bitvec.or (Bitvec.and (Bitvec.ofInt w X) (Bitvec.shl (Bitvec.ofInt w C2) (Bitvec.toNat (Bitvec.ofInt w C))))
         (Bitvec.shl (Bitvec.ofInt w Y) (Bitvec.toNat (Bitvec.ofInt w C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__497 :
  ∀ (w : ℕ) (X C2 C : ℤ),
@@ -930,7 +1154,9 @@ theorem bitvec_InstCombineShift__497 :
     some
       (Bitvec.xor (Bitvec.ushr (Bitvec.ofInt w X) (Bitvec.toNat (Bitvec.ofInt w C)))
         (Bitvec.ushr (Bitvec.ofInt w C2) (Bitvec.toNat (Bitvec.ofInt w C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__497''' :
  ∀ (w : ℕ) (X C2 C : ℤ),
@@ -938,7 +1164,9 @@ theorem bitvec_InstCombineShift__497''' :
     some
       (Bitvec.add (Bitvec.shl (Bitvec.ofInt w X) (Bitvec.toNat (Bitvec.ofInt w C)))
         (Bitvec.shl (Bitvec.ofInt w C2) (Bitvec.toNat (Bitvec.ofInt w C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__582 :
  ∀ (w : ℕ) (X C : ℤ),
@@ -946,7 +1174,9 @@ theorem bitvec_InstCombineShift__582 :
       (Bitvec.ushr (Bitvec.shl (Bitvec.ofInt w X) (Bitvec.toNat (Bitvec.ofInt w C)))
         (Bitvec.toNat (Bitvec.ofInt w C))) ⊑
     some (Bitvec.and (Bitvec.ofInt w X) (Bitvec.ushr (Bitvec.ofInt w (-1)) (Bitvec.toNat (Bitvec.ofInt w C))))
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry
 
 theorem bitvec_InstCombineShift__724:
  ∀ (C1 A C2 : ℤ),
@@ -957,4 +1187,6 @@ theorem bitvec_InstCombineShift__724:
       (Bitvec.shl (Bitvec.shl (Bitvec.ofInt 31 C1) (Bitvec.toNat (Bitvec.ofInt 31 C2)))
         (Bitvec.toNat (Bitvec.ofInt 31 A)))
 
-:=sorry
+:= by
+  simp only [Bitvec.refinement_some_some]
+  sorry

--- a/SSA/Projects/InstCombine/InstCombineBase.lean
+++ b/SSA/Projects/InstCombine/InstCombineBase.lean
@@ -112,23 +112,23 @@ def eval (o : Op)
   (_rgn : (Goedel.toType (rgnDom o) → Goedel.toType (rgnCod o))) :
   Goedel.toType (outUserType o) :=
     match o with
-    | Op.and _ => pairMapM Bitvec.and arg
-    | Op.or _ => pairMapM Bitvec.or arg
-    | Op.xor _ => pairMapM Bitvec.xor arg
+    | Op.and _ => pairMapM (.&&&.) arg
+    | Op.or _ => pairMapM (.|||.) arg
+    | Op.xor _ => pairMapM (.^^^.) arg
     | Op.shl _ => pairMapM (fun fst snd => Bitvec.shl fst snd.toNat) arg
     | Op.lshr _ => pairMapM (fun fst snd => Bitvec.ushr fst snd.toNat) arg
     | Op.ashr _ => pairMapM (fun fst snd => Bitvec.sshr fst snd.toNat) arg
     | Op.const c => Option.some c
-    | Op.sub _ => pairMapM Bitvec.sub arg
-    | Op.add _ => pairMapM Bitvec.add arg
-    | Op.mul _ => pairMapM Bitvec.mul arg
+    | Op.sub _ => pairMapM (.-.) arg
+    | Op.add _ => pairMapM (.+.) arg
+    | Op.mul _ => pairMapM (.*.) arg
     | Op.sdiv _ => pairBind Bitvec.sdiv? arg
     | Op.udiv _ => pairBind Bitvec.udiv? arg
     | Op.urem _ => pairBind Bitvec.urem? arg
     | Op.srem _ => pairBind Bitvec.srem? arg
-    | Op.not _ => Option.map Bitvec.not arg
+    | Op.not _ => Option.map (~~~.) arg
     | Op.copy _ => arg
-    | Op.neg _ => Option.map Bitvec.neg arg
+    | Op.neg _ => Option.map (-.) arg
     | Op.select _ => tripleMapM Bitvec.select arg
     | Op.icmp c _ => match c with
       | Comparison.eq => pairMapM (fun x y => ↑(x == y)) arg


### PR DESCRIPTION
**Before**
```lean
∀ (w : ℕ) (Z C1 RHS : ℤ),
  some
      (Bitvec.add
        (Bitvec.add (Bitvec.xor (Bitvec.and (Bitvec.ofInt w Z) (Bitvec.ofInt w C1)) (Bitvec.ofInt w C1))
          (Bitvec.ofInt w 1))
        (Bitvec.ofInt w RHS)) ⊑
    some (Bitvec.sub (Bitvec.ofInt w RHS) (Bitvec.or (Bitvec.ofInt w Z) (Bitvec.not (Bitvec.ofInt w C1))))
```
**After**
```lean
∀ (w : ℕ) (Z C1 RHS : ℤ),
  (Bitvec.ofInt w Z &&& Bitvec.ofInt w C1 ^^^ Bitvec.ofInt w C1) + Bitvec.ofInt w 1 + Bitvec.ofInt w RHS =
    Bitvec.ofInt w RHS - (Bitvec.ofInt w Z ||| ~~~Bitvec.ofInt w C1)
```