### PR TITLE
alive: remove old ofInt' definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run executable ⚙️
         run: |
-          ./build/bin/mlirnatural instcombine-test1 "32,2,3" | grep "^some 3$"
+          ./build/bin/mlirnatural instcombine-test1 "32,2,3" | grep "^some -2$"
   
       - name: Generate docs 📜
         run: |

--- a/SSA/Projects/InstCombine/InstCombineBase.lean
+++ b/SSA/Projects/InstCombine/InstCombineBase.lean
@@ -150,25 +150,6 @@ instance TUS : SSA.TypedUserSemantics Op BaseType where
   outUserType := outUserType
   eval := eval
 
-/-- Create a bitvector in the two's complement representation from an `int`
-  We need such a coercion to keep the bit-width the same, as compared to the
-  Mathlib version which adds an extra bit!
-  @goens: can you figure out how to do this properly? Once again,
-  the API I define below is what I would expect in LLVM!
--/
--- protected def ofInt : ∀ n : ℕ, Int → Bitvec (succ n)
-def Bitvec.ofInt' (n : ℕ) (i : Int) : Bitvec n :=
-  Bitvec.ofNat n (Int.toNat i)
-
-
-/-
-Optimization: InstCombineShift: 279
-  %Op0 = lshr %X, C
-  %r = shl %Op0, C
-=>
-  %r = and %X, (-1 << C)
--/
-
 open EDSL
 syntax "add" term : dsl_op
 syntax "and" term : dsl_op

--- a/SSA/Projects/InstCombine/InstCombineBase.lean
+++ b/SSA/Projects/InstCombine/InstCombineBase.lean
@@ -4,11 +4,6 @@ import SSA.Projects.InstCombine.ForMathlib
 
 namespace InstCombine
 
--- allow to create constants of width 0 too, so that type unification doesn't fail because of coercionbbrev Width := ℕ+
--- abbrev Width := ℕ+
--- instance {n : Nat} [inst : NeZero n] : OfNat Width n where
---   ofNat := ⟨n, (by have h : n ≠ 0 := inst.out; cases n <;> aesop )⟩
-
 inductive BaseType
   | bitvec (w : Nat) : BaseType
   deriving DecidableEq

--- a/SSA/Projects/InstCombine/Tests.lean
+++ b/SSA/Projects/InstCombine/Tests.lean
@@ -9,11 +9,11 @@ def test1 (params : Nat × Nat × Nat) : IO Bool := do
     [dsl_bb|
     ^bb
     %v9999 := unit: ;
-    %v1 := op:const (Bitvec.ofInt' w A) %v9999;
-    %v2 := op:const (Bitvec.ofInt' w B) %v9999;
+    %v1 := op:const (Bitvec.ofInt w A) %v9999;
+    %v2 := op:const (Bitvec.ofInt w B) %v9999;
     %v3 := pair:%v1 %v2;
     %v4 := op:xor w %v3;
-    %v5 := op:const (Bitvec.ofInt' w (-1)) %v9999;
+    %v5 := op:const (Bitvec.ofInt w (-1)) %v9999;
     %v6 := pair:%v4 %v5;
     %v7 := op:xor w %v6;
     %v8 := pair:%v1 %v7;


### PR DESCRIPTION
This has meanwhile be upstreamed to mathlib.