### PR TITLE
alive: use 0/1/-1 to simplify notation

### DIFF
--- a/SSA/Projects/InstCombine/Alive.lean
+++ b/SSA/Projects/InstCombine/Alive.lean
@@ -36,7 +36,7 @@ theorem alive_AddSub_1043 : forall (w : Nat) (C1 Z RHS : Bitvec w)
   %v4 := op:and w %v3;
   %v5 := pair:%v4 %v2;
   %v6 := op:xor w %v5;
-  %v7 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v7 := op:const (1) %v0;
   %v8 := pair:%v6 %v7;
   %v9 := op:add w %v8;
   %v10 := op:const (RHS) %v0;
@@ -59,7 +59,7 @@ theorem alive_AddSub_1043 : forall (w : Nat) (C1 Z RHS : Bitvec w)
   %v7 := op:and w %v6;
   %v8 := pair:%v7 %v2;
   %v9 := op:xor w %v8;
-  %v10 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v10 := op:const (1) %v0;
   %v11 := pair:%v9 %v10;
   %v12 := op:add w %v11;
   %v13 := op:const (RHS) %v0;
@@ -139,7 +139,7 @@ theorem alive_AddSub_1156 : forall (w : Nat) (b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (b) %v0;
-  %v2 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v2 := op:const (1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl w %v3
   dsl_ret %v4
@@ -177,7 +177,7 @@ theorem alive_AddSub_1156_2 : forall (w : Nat) (b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (b) %v0;
-  %v2 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v2 := op:const (1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl w %v3
   dsl_ret %v4
@@ -215,7 +215,7 @@ theorem alive_AddSub_1156_3 : forall (w : Nat) (b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (b) %v0;
-  %v2 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v2 := op:const (1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl w %v3
   dsl_ret %v4
@@ -243,7 +243,7 @@ theorem alive_AddSub_1164 : forall (w : Nat) (a b : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (a) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
@@ -258,7 +258,7 @@ theorem alive_AddSub_1164 : forall (w : Nat) (a b : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (a) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
@@ -293,11 +293,11 @@ theorem alive_AddSub_1165 : forall (w : Nat) (a b : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (a) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := op:const (b) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:sub w %v7;
@@ -315,13 +315,13 @@ theorem alive_AddSub_1165 : forall (w : Nat) (a b : Bitvec w)
   %v2 := op:const (b) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:add w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:sub w %v6;
-  %v8 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := pair:%v8 %v2;
   %v10 := op:sub w %v9;
-  %v11 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v11 := op:const (0) %v0;
   %v12 := pair:%v11 %v4;
   %v13 := op:sub w %v12
   dsl_ret %v13
@@ -349,7 +349,7 @@ theorem alive_AddSub_1176 : forall (w : Nat) (a b : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (b) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
@@ -364,7 +364,7 @@ theorem alive_AddSub_1176 : forall (w : Nat) (a b : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (b) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
@@ -397,7 +397,7 @@ theorem alive_AddSub_1202 : forall (w : Nat) (x C : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (C) %v0;
@@ -412,11 +412,11 @@ theorem alive_AddSub_1202 : forall (w : Nat) (x C : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (C) %v0;
-  %v6 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v6 := op:const (1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:sub w %v7;
   %v9 := pair:%v8 %v1;
@@ -650,7 +650,7 @@ theorem alive_AddSub_1539 : forall (w : Nat) (a x : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (a) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
@@ -665,7 +665,7 @@ theorem alive_AddSub_1539 : forall (w : Nat) (a x : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (a) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
@@ -737,7 +737,7 @@ theorem alive_AddSub_1546 : forall (w : Nat) (a x : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (a) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
@@ -752,7 +752,7 @@ theorem alive_AddSub_1546 : forall (w : Nat) (a x : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (a) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
@@ -821,7 +821,7 @@ theorem alive_AddSub_1560 : forall (w : Nat) (a : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v1 := op:const (-1) %v0;
   %v2 := op:const (a) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3
@@ -834,7 +834,7 @@ theorem alive_AddSub_1560 : forall (w : Nat) (a : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3
   dsl_ret %v4
@@ -863,7 +863,7 @@ theorem alive_AddSub_1564 : forall (w : Nat) (x C : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (C) %v0;
@@ -878,11 +878,11 @@ theorem alive_AddSub_1564 : forall (w : Nat) (x C : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (C) %v0;
-  %v6 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v6 := op:const (1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:add w %v7;
   %v9 := pair:%v1 %v8;
@@ -979,7 +979,7 @@ theorem alive_AddSub_1614 : forall (w : Nat) (Y X : Bitvec w)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:add w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub w %v6
   dsl_ret %v7
@@ -1025,7 +1025,7 @@ theorem alive_AddSub_1619 : forall (w : Nat) (Y X : Bitvec w)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub w %v6
   dsl_ret %v7
@@ -1223,10 +1223,10 @@ theorem alive_AndOrXor_698 : forall (w : Nat) (a b d : Bitvec w)
   %v5 := op:const (d) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:and w %v6;
-  %v8 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := pair:%v4 %v8;
   %v10 := op:icmp eq  w %v9;
-  %v11 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v11 := op:const (0) %v0;
   %v12 := pair:%v7 %v11;
   %v13 := op:icmp eq  w %v12;
   %v14 := pair:%v10 %v13;
@@ -1250,13 +1250,13 @@ theorem alive_AndOrXor_698 : forall (w : Nat) (a b d : Bitvec w)
   %v9 := op:and w %v8;
   %v10 := pair:%v5 %v2;
   %v11 := op:and w %v10;
-  %v12 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v12 := op:const (0) %v0;
   %v13 := pair:%v9 %v12;
   %v14 := op:icmp eq  w %v13;
-  %v15 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v15 := op:const (0) %v0;
   %v16 := pair:%v11 %v15;
   %v17 := op:icmp eq  w %v16;
-  %v18 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v18 := op:const (0) %v0;
   %v19 := pair:%v7 %v18;
   %v20 := op:icmp eq  w %v19
   dsl_ret %v20
@@ -1481,11 +1481,11 @@ theorem alive_AndOrXor_827 : forall (w : Nat) (a b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp eq  w %v3;
   %v5 := op:const (b) %v0;
-  %v6 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v6 := op:const (0) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:icmp eq  w %v7;
   %v9 := pair:%v4 %v8;
@@ -1502,13 +1502,13 @@ theorem alive_AndOrXor_827 : forall (w : Nat) (a b : Bitvec w)
   %v2 := op:const (b) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:or w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:icmp eq  w %v6;
-  %v8 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := pair:%v2 %v8;
   %v10 := op:icmp eq  w %v9;
-  %v11 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v11 := op:const (0) %v0;
   %v12 := pair:%v4 %v11;
   %v13 := op:icmp eq  w %v12
   dsl_ret %v13
@@ -1591,11 +1591,11 @@ theorem alive_AndOrXor_1230__A__B___A__B : forall (w : Nat) (notOp0 notOp1 : Bit
   ^bb
   %v0 := unit: ;
   %v1 := op:const (notOp0) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (notOp1) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v4 %v8;
@@ -1612,13 +1612,13 @@ theorem alive_AndOrXor_1230__A__B___A__B : forall (w : Nat) (notOp0 notOp1 : Bit
   %v2 := op:const (notOp1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:or w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:xor w %v6;
-  %v8 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v8 := op:const (-1) %v0;
   %v9 := pair:%v2 %v8;
   %v10 := op:xor w %v9;
-  %v11 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v11 := op:const (-1) %v0;
   %v12 := pair:%v4 %v11;
   %v13 := op:xor w %v12
   dsl_ret %v13
@@ -1656,7 +1656,7 @@ theorem alive_AndOrXor_1241_AB__AB__AB : forall (w : Nat) (A B : Bitvec w)
   %v4 := op:or w %v3;
   %v5 := pair:%v1 %v2;
   %v6 := op:and w %v5;
-  %v7 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v7 := op:const (-1) %v0;
   %v8 := pair:%v6 %v7;
   %v9 := op:xor w %v8;
   %v10 := pair:%v4 %v9;
@@ -1675,7 +1675,7 @@ theorem alive_AndOrXor_1241_AB__AB__AB : forall (w : Nat) (A B : Bitvec w)
   %v4 := op:or w %v3;
   %v5 := pair:%v1 %v2;
   %v6 := op:and w %v5;
-  %v7 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v7 := op:const (-1) %v0;
   %v8 := pair:%v6 %v7;
   %v9 := op:xor w %v8;
   %v10 := pair:%v1 %v2;
@@ -1713,7 +1713,7 @@ theorem alive_AndOrXor_1247_AB__AB__AB : forall (w : Nat) (A B : Bitvec w)
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:and w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor w %v6;
   %v8 := pair:%v1 %v2;
@@ -1732,7 +1732,7 @@ theorem alive_AndOrXor_1247_AB__AB__AB : forall (w : Nat) (A B : Bitvec w)
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:and w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor w %v6;
   %v8 := pair:%v1 %v2;
@@ -1780,7 +1780,7 @@ theorem alive_AndOrXor_1253_A__AB___A__B : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (A) %v0;
@@ -1816,7 +1816,7 @@ theorem alive_AndOrXor_1280_ABA___AB : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
@@ -1833,7 +1833,7 @@ theorem alive_AndOrXor_1280_ABA___AB : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
@@ -1895,7 +1895,7 @@ theorem alive_AndOrXor_1288_A__B__B__C__A___A__B__C : forall (w : Nat) (A C B : 
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (C) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v2 %v5;
@@ -1937,7 +1937,7 @@ theorem alive_AndOrXor_1294_A__B__A__B___A__B : forall (w : Nat) (A B : Bitvec w
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:or w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:xor w %v6;
   %v8 := pair:%v7 %v2;
@@ -1956,7 +1956,7 @@ theorem alive_AndOrXor_1294_A__B__A__B___A__B : forall (w : Nat) (A B : Bitvec w
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:or w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:xor w %v6;
   %v8 := pair:%v7 %v2;
@@ -2094,7 +2094,7 @@ theorem alive_AndOrXor_1704 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp eq  w %v3;
   %v5 := op:const (A) %v0;
@@ -2111,10 +2111,10 @@ theorem alive_AndOrXor_1704 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:add w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:icmp eq  w %v6;
   %v8 := op:const (A) %v0;
@@ -2151,7 +2151,7 @@ theorem alive_AndOrXor_1705 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp eq  w %v3;
   %v5 := op:const (A) %v0;
@@ -2168,10 +2168,10 @@ theorem alive_AndOrXor_1705 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:add w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:icmp eq  w %v6;
   %v8 := op:const (A) %v0;
@@ -2208,11 +2208,11 @@ theorem alive_AndOrXor_1733 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp ne  w %v3;
   %v5 := op:const (B) %v0;
-  %v6 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v6 := op:const (0) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:icmp ne  w %v7;
   %v9 := pair:%v4 %v8;
@@ -2229,13 +2229,13 @@ theorem alive_AndOrXor_1733 : forall (w : Nat) (A B : Bitvec w)
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:or w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:icmp ne  w %v6;
-  %v8 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := pair:%v2 %v8;
   %v10 := op:icmp ne  w %v9;
-  %v11 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v11 := op:const (0) %v0;
   %v12 := pair:%v4 %v11;
   %v13 := op:icmp ne  w %v12
   dsl_ret %v13
@@ -2319,7 +2319,7 @@ theorem alive_AndOrXor_2113___A__B__A___A__B : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
@@ -2336,7 +2336,7 @@ theorem alive_AndOrXor_2113___A__B__A___A__B : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
@@ -2372,7 +2372,7 @@ theorem alive_AndOrXor_2118___A__B__A___A__B : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
@@ -2389,7 +2389,7 @@ theorem alive_AndOrXor_2118___A__B__A___A__B : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
@@ -2427,7 +2427,7 @@ theorem alive_AndOrXor_2123___A__B__A__B___A__B : forall (w : Nat) (A B : Bitvec
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (A) %v0;
@@ -2446,7 +2446,7 @@ theorem alive_AndOrXor_2123___A__B__A__B___A__B : forall (w : Nat) (A B : Bitvec
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (A) %v0;
@@ -2488,11 +2488,11 @@ theorem alive_AndOrXor_2188 : forall (w : Nat) (A D : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (D) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (A) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v5 %v4;
@@ -2510,11 +2510,11 @@ theorem alive_AndOrXor_2188 : forall (w : Nat) (A D : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (D) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (A) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v5 %v4;
@@ -2667,11 +2667,11 @@ theorem alive_AndOrXor_2247__A__B__A__B : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v4 %v8;
@@ -2688,13 +2688,13 @@ theorem alive_AndOrXor_2247__A__B__A__B : forall (w : Nat) (A B : Bitvec w)
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:and w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:xor w %v6;
-  %v8 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v8 := op:const (-1) %v0;
   %v9 := pair:%v2 %v8;
   %v10 := op:xor w %v9;
-  %v11 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v11 := op:const (-1) %v0;
   %v12 := pair:%v4 %v11;
   %v13 := op:xor w %v12
   dsl_ret %v13
@@ -2771,7 +2771,7 @@ theorem alive_AndOrXor_2264 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
@@ -2788,11 +2788,11 @@ theorem alive_AndOrXor_2264 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (A) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v8 %v1;
@@ -2882,7 +2882,7 @@ theorem alive_AndOrXor_2284 : forall (w : Nat) (A B : Bitvec w)
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:or w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor w %v6;
   %v8 := pair:%v1 %v7;
@@ -2896,13 +2896,13 @@ theorem alive_AndOrXor_2284 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (A) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:or w %v6;
-  %v8 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v8 := op:const (-1) %v0;
   %v9 := pair:%v7 %v8;
   %v10 := op:xor w %v9;
   %v11 := pair:%v5 %v4;
@@ -2939,7 +2939,7 @@ theorem alive_AndOrXor_2285 : forall (w : Nat) (A B : Bitvec w)
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor w %v6;
   %v8 := pair:%v1 %v7;
@@ -2953,13 +2953,13 @@ theorem alive_AndOrXor_2285 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (B) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (A) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:xor w %v6;
-  %v8 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v8 := op:const (-1) %v0;
   %v9 := pair:%v7 %v8;
   %v10 := op:xor w %v9;
   %v11 := pair:%v5 %v4;
@@ -2997,7 +2997,7 @@ theorem alive_AndOrXor_2297 : forall (w : Nat) (A B : Bitvec w)
   %v2 := op:const (B) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:and w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v1 %v5;
   %v7 := op:xor w %v6;
   %v8 := pair:%v7 %v2;
@@ -3013,7 +3013,7 @@ theorem alive_AndOrXor_2297 : forall (w : Nat) (A B : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (B) %v0;
@@ -3102,13 +3102,13 @@ theorem alive_AndOrXor_2416 : forall (w : Nat) (nx y : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (nx) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (y) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:and w %v6;
-  %v8 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v8 := op:const (-1) %v0;
   %v9 := pair:%v7 %v8;
   %v10 := op:xor w %v9
   dsl_ret %v10
@@ -3120,11 +3120,11 @@ theorem alive_AndOrXor_2416 : forall (w : Nat) (nx y : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (y) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (nx) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v8 %v1;
@@ -3160,13 +3160,13 @@ theorem alive_AndOrXor_2417 : forall (w : Nat) (nx y : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (nx) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (y) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:or w %v6;
-  %v8 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v8 := op:const (-1) %v0;
   %v9 := pair:%v7 %v8;
   %v10 := op:xor w %v9
   dsl_ret %v10
@@ -3178,11 +3178,11 @@ theorem alive_AndOrXor_2417 : forall (w : Nat) (nx y : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (y) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (nx) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v8 %v1;
@@ -3220,7 +3220,7 @@ theorem alive_AndOrXor_2429 : forall (w : Nat) (y x : Bitvec w)
   %v2 := op:const (y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:and w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor w %v6
   dsl_ret %v7
@@ -3232,11 +3232,11 @@ theorem alive_AndOrXor_2429 : forall (w : Nat) (y x : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (y) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v1 %v5;
@@ -3274,7 +3274,7 @@ theorem alive_AndOrXor_2430 : forall (w : Nat) (y x : Bitvec w)
   %v2 := op:const (y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:or w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor w %v6
   dsl_ret %v7
@@ -3286,11 +3286,11 @@ theorem alive_AndOrXor_2430 : forall (w : Nat) (y x : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (y) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v1 %v5;
@@ -3325,13 +3325,13 @@ theorem alive_AndOrXor_2443 : forall (w : Nat) (y x : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (y) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:ashr w %v6;
-  %v8 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v8 := op:const (-1) %v0;
   %v9 := pair:%v7 %v8;
   %v10 := op:xor w %v9
   dsl_ret %v10
@@ -3343,7 +3343,7 @@ theorem alive_AndOrXor_2443 : forall (w : Nat) (y x : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (y) %v0;
@@ -3380,7 +3380,7 @@ theorem alive_AndOrXor_2453 : forall (w : Nat) (y x : Bitvec w)
   %v2 := op:const (y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp slt  w %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (-1)) %v0;
+  %v5 := op:const ((-1)) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor 1 %v6
   dsl_ret %v7
@@ -3426,7 +3426,7 @@ theorem alive_AndOrXor_2475 : forall (w : Nat) (x C : Bitvec w)
   %v2 := op:const (x) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor w %v6
   dsl_ret %v7
@@ -3441,7 +3441,7 @@ theorem alive_AndOrXor_2475 : forall (w : Nat) (x C : Bitvec w)
   %v2 := op:const (x) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:sub w %v6;
   %v8 := pair:%v2 %v7;
@@ -3475,7 +3475,7 @@ theorem alive_AndOrXor_2486 : forall (w : Nat) (x C : Bitvec w)
   %v2 := op:const (C) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:add w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor w %v6
   dsl_ret %v7
@@ -3490,7 +3490,7 @@ theorem alive_AndOrXor_2486 : forall (w : Nat) (x C : Bitvec w)
   %v2 := op:const (C) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:add w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub w %v6;
   %v8 := pair:%v7 %v1;
@@ -3536,7 +3536,7 @@ theorem alive_AndOrXor_2581__BAB___A__B : forall (w : Nat) (a op1 : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (op1) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (a) %v0;
@@ -3585,7 +3585,7 @@ theorem alive_AndOrXor_2587__BAA___B__A : forall (w : Nat) (a op1 : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (op1) %v0;
@@ -3676,11 +3676,11 @@ theorem alive_AndOrXor_2607 : forall (w : Nat) (a b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (b) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v1 %v8;
@@ -3698,11 +3698,11 @@ theorem alive_AndOrXor_2607 : forall (w : Nat) (a b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (b) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v1 %v8;
@@ -3743,11 +3743,11 @@ theorem alive_AndOrXor_2617 : forall (w : Nat) (a b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (b) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v1 %v8;
@@ -3765,11 +3765,11 @@ theorem alive_AndOrXor_2617 : forall (w : Nat) (a b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (b) %v0;
-  %v6 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v6 := op:const (-1) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:xor w %v7;
   %v9 := pair:%v1 %v8;
@@ -3825,7 +3825,7 @@ theorem alive_AndOrXor_2627 : forall (w : Nat) (a c b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (b) %v0;
@@ -3920,13 +3920,13 @@ theorem alive_AndOrXor_2658 : forall (w : Nat) (a b : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (b) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (a) %v0;
   %v6 := pair:%v5 %v4;
   %v7 := op:and w %v6;
-  %v8 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v8 := op:const (-1) %v0;
   %v9 := pair:%v5 %v8;
   %v10 := op:xor w %v9;
   %v11 := pair:%v7 %v10;
@@ -3943,15 +3943,15 @@ theorem alive_AndOrXor_2658 : forall (w : Nat) (a b : Bitvec w)
   %v2 := op:const (b) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:and w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v2 %v5;
   %v7 := op:xor w %v6;
   %v8 := pair:%v1 %v7;
   %v9 := op:and w %v8;
-  %v10 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v10 := op:const (-1) %v0;
   %v11 := pair:%v1 %v10;
   %v12 := op:xor w %v11;
-  %v13 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v13 := op:const (-1) %v0;
   %v14 := pair:%v4 %v13;
   %v15 := op:xor w %v14
   dsl_ret %v15
@@ -4029,7 +4029,7 @@ theorem alive_152 : forall (w : Nat) (x : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (x) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:mul w %v3
   dsl_ret %v4
@@ -4040,7 +4040,7 @@ theorem alive_152 : forall (w : Nat) (x : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (x) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3
@@ -4173,11 +4173,11 @@ theorem alive_239 : forall (w : Nat) (Y X : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (X) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := op:const (Y) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:sub w %v7;
@@ -4191,11 +4191,11 @@ theorem alive_239 : forall (w : Nat) (Y X : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (X) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := op:const (Y) %v0;
   %v7 := pair:%v5 %v6;
   %v8 := op:sub w %v7;
@@ -4320,7 +4320,7 @@ theorem alive_266 : forall (w : Nat) (Y X : Bitvec w)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:udiv w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub w %v6;
   %v8 := pair:%v4 %v7;
@@ -4337,10 +4337,10 @@ theorem alive_266 : forall (w : Nat) (Y X : Bitvec w)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:udiv w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub w %v6;
-  %v8 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := pair:%v8 %v1;
   %v10 := op:sub w %v9
   dsl_ret %v10
@@ -4374,7 +4374,7 @@ theorem alive_266_2 : forall (w : Nat) (Y X : Bitvec w)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sdiv w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub w %v6;
   %v8 := pair:%v4 %v7;
@@ -4391,10 +4391,10 @@ theorem alive_266_2 : forall (w : Nat) (Y X : Bitvec w)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sdiv w %v3;
-  %v5 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub w %v6;
-  %v8 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := pair:%v8 %v1;
   %v10 := op:sub w %v9
   dsl_ret %v10
@@ -4525,7 +4525,7 @@ theorem alive_276: forall (Y X : Bitvec 5)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sdiv 5 %v3;
-  %v5 := op:const (Bitvec.ofInt 5 (0)) %v0;
+  %v5 := op:const ((0)) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub 5 %v6;
   %v8 := pair:%v4 %v7;
@@ -4544,7 +4544,7 @@ theorem alive_276: forall (Y X : Bitvec 5)
   %v4 := op:srem 5 %v3;
   %v5 := pair:%v1 %v2;
   %v6 := op:sdiv 5 %v5;
-  %v7 := op:const (Bitvec.ofInt 5 (0)) %v0;
+  %v7 := op:const ((0)) %v0;
   %v8 := pair:%v7 %v2;
   %v9 := op:sub 5 %v8;
   %v10 := pair:%v4 %v1;
@@ -4581,7 +4581,7 @@ theorem alive_276_2: forall (Y X : Bitvec 5)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:udiv 5 %v3;
-  %v5 := op:const (Bitvec.ofInt 5 (0)) %v0;
+  %v5 := op:const ((0)) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub 5 %v6;
   %v8 := pair:%v4 %v7;
@@ -4600,7 +4600,7 @@ theorem alive_276_2: forall (Y X : Bitvec 5)
   %v4 := op:urem 5 %v3;
   %v5 := pair:%v1 %v2;
   %v6 := op:udiv 5 %v5;
-  %v7 := op:const (Bitvec.ofInt 5 (0)) %v0;
+  %v7 := op:const ((0)) %v0;
   %v8 := pair:%v7 %v2;
   %v9 := op:sub 5 %v8;
   %v10 := pair:%v4 %v1;
@@ -4669,7 +4669,7 @@ theorem alive_290__292 : forall (w : Nat) (Y Op1 : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v1 := op:const (1) %v0;
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl w %v3;
@@ -4684,7 +4684,7 @@ theorem alive_290__292 : forall (w : Nat) (Y Op1 : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v1 := op:const (1) %v0;
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl w %v3;
@@ -4818,7 +4818,7 @@ theorem alive_891: forall (x N : Bitvec 13)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt 13 (1)) %v0;
+  %v1 := op:const ((1)) %v0;
   %v2 := op:const (N) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl 13 %v3;
@@ -4833,7 +4833,7 @@ theorem alive_891: forall (x N : Bitvec 13)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt 13 (1)) %v0;
+  %v1 := op:const ((1)) %v0;
   %v2 := op:const (N) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl 13 %v3;
@@ -4865,7 +4865,7 @@ theorem alive_891_exact: forall (x N : Bitvec 13)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt 13 (1)) %v0;
+  %v1 := op:const ((1)) %v0;
   %v2 := op:const (N) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl 13 %v3;
@@ -4880,7 +4880,7 @@ theorem alive_891_exact: forall (x N : Bitvec 13)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt 13 (1)) %v0;
+  %v1 := op:const ((1)) %v0;
   %v2 := op:const (N) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl 13 %v3;
@@ -4911,7 +4911,7 @@ theorem alive_1030 : forall (w : Nat) (X : Bitvec w)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (X) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sdiv w %v3
   dsl_ret %v4
@@ -4922,7 +4922,7 @@ theorem alive_1030 : forall (w : Nat) (X : Bitvec w)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (X) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub w %v3
@@ -4951,7 +4951,7 @@ theorem alive_1049: forall (X C : Bitvec 11)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt 11 (0)) %v0;
+  %v1 := op:const ((0)) %v0;
   %v2 := op:const (X) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub 11 %v3;
@@ -4966,7 +4966,7 @@ theorem alive_1049: forall (X C : Bitvec 11)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt 11 (0)) %v0;
+  %v1 := op:const ((0)) %v0;
   %v2 := op:const (X) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub 11 %v3;
@@ -5339,7 +5339,7 @@ theorem alive_InstCombineShift__239 : forall (w : Nat) (X C : Bitvec w)
   %v2 := op:const (C) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:lshr w %v6;
   %v8 := pair:%v1 %v7;
@@ -5387,7 +5387,7 @@ theorem alive_InstCombineShift__279 : forall (w : Nat) (X C : Bitvec w)
   %v2 := op:const (C) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:lshr w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:shl w %v6;
   %v8 := pair:%v1 %v7;
@@ -5498,7 +5498,7 @@ theorem alive_InstCombineShift__422_1: forall (Y X C : Bitvec 31)
   %v9 := op:lshr 31 %v8;
   %v10 := pair:%v1 %v9;
   %v11 := op:add 31 %v10;
-  %v12 := op:const (Bitvec.ofInt 31 (-1)) %v0;
+  %v12 := op:const ((-1)) %v0;
   %v13 := pair:%v12 %v2;
   %v14 := op:shl 31 %v13;
   %v15 := pair:%v7 %v14;
@@ -5560,7 +5560,7 @@ theorem alive_InstCombineShift__422_2: forall (Y X C : Bitvec 31)
   %v9 := op:ashr 31 %v8;
   %v10 := pair:%v1 %v9;
   %v11 := op:add 31 %v10;
-  %v12 := op:const (Bitvec.ofInt 31 (-1)) %v0;
+  %v12 := op:const ((-1)) %v0;
   %v13 := pair:%v12 %v2;
   %v14 := op:shl 31 %v13;
   %v15 := pair:%v7 %v14;
@@ -5691,7 +5691,7 @@ theorem alive_InstCombineShift__458: forall (Y X C : Bitvec 31)
   %v9 := op:ashr 31 %v8;
   %v10 := pair:%v9 %v1;
   %v11 := op:sub 31 %v10;
-  %v12 := op:const (Bitvec.ofInt 31 (-1)) %v0;
+  %v12 := op:const ((-1)) %v0;
   %v13 := pair:%v12 %v2;
   %v14 := op:shl 31 %v13;
   %v15 := pair:%v7 %v14;
@@ -5912,7 +5912,7 @@ theorem alive_InstCombineShift__582 : forall (w : Nat) (X C : Bitvec w)
   %v2 := op:const (C) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl w %v3;
-  %v5 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:lshr w %v6;
   %v8 := pair:%v1 %v7;

--- a/SSA/Projects/InstCombine/Alive.lean
+++ b/SSA/Projects/InstCombine/Alive.lean
@@ -3380,7 +3380,7 @@ theorem alive_AndOrXor_2453 : forall (w : Nat) (y x : Bitvec w)
   %v2 := op:const (y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp slt  w %v3;
-  %v5 := op:const ((-1)) %v0;
+  %v5 := op:const (-1) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:xor 1 %v6
   dsl_ret %v7
@@ -4525,7 +4525,7 @@ theorem alive_276: forall (Y X : Bitvec 5)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sdiv 5 %v3;
-  %v5 := op:const ((0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub 5 %v6;
   %v8 := pair:%v4 %v7;
@@ -4544,7 +4544,7 @@ theorem alive_276: forall (Y X : Bitvec 5)
   %v4 := op:srem 5 %v3;
   %v5 := pair:%v1 %v2;
   %v6 := op:sdiv 5 %v5;
-  %v7 := op:const ((0)) %v0;
+  %v7 := op:const (0) %v0;
   %v8 := pair:%v7 %v2;
   %v9 := op:sub 5 %v8;
   %v10 := pair:%v4 %v1;
@@ -4581,7 +4581,7 @@ theorem alive_276_2: forall (Y X : Bitvec 5)
   %v2 := op:const (Y) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:udiv 5 %v3;
-  %v5 := op:const ((0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v2;
   %v7 := op:sub 5 %v6;
   %v8 := pair:%v4 %v7;
@@ -4600,7 +4600,7 @@ theorem alive_276_2: forall (Y X : Bitvec 5)
   %v4 := op:urem 5 %v3;
   %v5 := pair:%v1 %v2;
   %v6 := op:udiv 5 %v5;
-  %v7 := op:const ((0)) %v0;
+  %v7 := op:const (0) %v0;
   %v8 := pair:%v7 %v2;
   %v9 := op:sub 5 %v8;
   %v10 := pair:%v4 %v1;
@@ -4818,7 +4818,7 @@ theorem alive_891: forall (x N : Bitvec 13)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const ((1)) %v0;
+  %v1 := op:const (1) %v0;
   %v2 := op:const (N) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl 13 %v3;
@@ -4833,7 +4833,7 @@ theorem alive_891: forall (x N : Bitvec 13)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const ((1)) %v0;
+  %v1 := op:const (1) %v0;
   %v2 := op:const (N) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl 13 %v3;
@@ -4865,7 +4865,7 @@ theorem alive_891_exact: forall (x N : Bitvec 13)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const ((1)) %v0;
+  %v1 := op:const (1) %v0;
   %v2 := op:const (N) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl 13 %v3;
@@ -4880,7 +4880,7 @@ theorem alive_891_exact: forall (x N : Bitvec 13)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const ((1)) %v0;
+  %v1 := op:const (1) %v0;
   %v2 := op:const (N) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:shl 13 %v3;
@@ -4951,7 +4951,7 @@ theorem alive_1049: forall (X C : Bitvec 11)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const ((0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (X) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub 11 %v3;
@@ -4966,7 +4966,7 @@ theorem alive_1049: forall (X C : Bitvec 11)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const ((0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (X) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub 11 %v3;
@@ -5498,7 +5498,7 @@ theorem alive_InstCombineShift__422_1: forall (Y X C : Bitvec 31)
   %v9 := op:lshr 31 %v8;
   %v10 := pair:%v1 %v9;
   %v11 := op:add 31 %v10;
-  %v12 := op:const ((-1)) %v0;
+  %v12 := op:const (-1) %v0;
   %v13 := pair:%v12 %v2;
   %v14 := op:shl 31 %v13;
   %v15 := pair:%v7 %v14;
@@ -5560,7 +5560,7 @@ theorem alive_InstCombineShift__422_2: forall (Y X C : Bitvec 31)
   %v9 := op:ashr 31 %v8;
   %v10 := pair:%v1 %v9;
   %v11 := op:add 31 %v10;
-  %v12 := op:const ((-1)) %v0;
+  %v12 := op:const (-1) %v0;
   %v13 := pair:%v12 %v2;
   %v14 := op:shl 31 %v13;
   %v15 := pair:%v7 %v14;
@@ -5691,7 +5691,7 @@ theorem alive_InstCombineShift__458: forall (Y X C : Bitvec 31)
   %v9 := op:ashr 31 %v8;
   %v10 := pair:%v9 %v1;
   %v11 := op:sub 31 %v10;
-  %v12 := op:const ((-1)) %v0;
+  %v12 := op:const (-1) %v0;
   %v13 := pair:%v12 %v2;
   %v14 := op:shl 31 %v13;
   %v15 := pair:%v7 %v14;

--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -2,7 +2,7 @@ import SSA.Projects.InstCombine.Base
 import SSA.Projects.InstCombine.Tactic
 
 theorem bitvec_AddSub_1043 :
- ∀ (w : ℕ) (C1 Z RHS : Bitvec w), (Z &&& C1 ^^^ C1) + Bitvec.ofInt w 1 + RHS = RHS - (Z ||| ~~~C1)
+ ∀ (w : ℕ) (C1 Z RHS : Bitvec w), (Z &&& C1 ^^^ C1) + 1 + RHS = RHS - (Z ||| ~~~C1)
 := by alive_auto
       try sorry
 
@@ -12,37 +12,37 @@ theorem bitvec_AddSub_1152:
       try sorry
 
 theorem bitvec_AddSub_1156 :
- ∀ (w : ℕ) (b : Bitvec w), b + b = b <<< Bitvec.ofInt w 1
+ ∀ (w : ℕ) (b : Bitvec w), b + b = b <<< 1
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1156_2 :
- ∀ (w : ℕ) (b : Bitvec w), b + b = b <<< Bitvec.ofInt w 1
+ ∀ (w : ℕ) (b : Bitvec w), b + b = b <<< 1
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1156_3 :
- ∀ (w : ℕ) (b : Bitvec w), b + b = b <<< Bitvec.ofInt w 1
+ ∀ (w : ℕ) (b : Bitvec w), b + b = b <<< 1
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1164 :
- ∀ (w : ℕ) (a b : Bitvec w), Bitvec.ofInt w 0 - a + b = b - a
+ ∀ (w : ℕ) (a b : Bitvec w), 0 - a + b = b - a
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1165 :
- ∀ (w : ℕ) (a b : Bitvec w), Bitvec.ofInt w 0 - a + (Bitvec.ofInt w 0 - b) = Bitvec.ofInt w 0 - (a + b)
+ ∀ (w : ℕ) (a b : Bitvec w), 0 - a + (0 - b) = 0 - (a + b)
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1176 :
- ∀ (w : ℕ) (a b : Bitvec w), a + (Bitvec.ofInt w 0 - b) = a - b
+ ∀ (w : ℕ) (a b : Bitvec w), a + (0 - b) = a - b
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1202 :
- ∀ (w : ℕ) (x C : Bitvec w), (x ^^^ Bitvec.ofInt w (-1)) + C = C - Bitvec.ofInt w 1 - x
+ ∀ (w : ℕ) (x C : Bitvec w), (x ^^^ (-1)) + C = C - 1 - x
 := by alive_auto
       try sorry
 
@@ -67,7 +67,7 @@ theorem bitvec_AddSub_1309_3 :
       try sorry
 
 theorem bitvec_AddSub_1539 :
- ∀ (w : ℕ) (a x : Bitvec w), x - (Bitvec.ofInt w 0 - a) = x + a
+ ∀ (w : ℕ) (a x : Bitvec w), x - (0 - a) = x + a
 := by alive_auto
       try sorry
 
@@ -77,7 +77,7 @@ theorem bitvec_AddSub_1539_2 :
       try sorry
 
 theorem bitvec_AddSub_1546 :
- ∀ (w : ℕ) (a x : Bitvec w), x - (Bitvec.ofInt w 0 - a) = x + a
+ ∀ (w : ℕ) (a x : Bitvec w), x - (0 - a) = x + a
 := by alive_auto
       try sorry
 
@@ -87,12 +87,12 @@ theorem bitvec_AddSub_1556:
       try sorry
 
 theorem bitvec_AddSub_1560 :
- ∀ (w : ℕ) (a : Bitvec w), Bitvec.ofInt w (-1) - a = a ^^^ Bitvec.ofInt w (-1)
+ ∀ (w : ℕ) (a : Bitvec w), (-1) - a = a ^^^ (-1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1564 :
- ∀ (w : ℕ) (x C : Bitvec w), C - (x ^^^ Bitvec.ofInt w (-1)) = x + (C + Bitvec.ofInt w 1)
+ ∀ (w : ℕ) (x C : Bitvec w), C - (x ^^^ (-1)) = x + (C + 1)
 := by alive_auto
       try sorry
 
@@ -102,12 +102,12 @@ theorem bitvec_AddSub_1574 :
       try sorry
 
 theorem bitvec_AddSub_1614 :
- ∀ (w : ℕ) (Y X : Bitvec w), X - (X + Y) = Bitvec.ofInt w 0 - Y
+ ∀ (w : ℕ) (Y X : Bitvec w), X - (X + Y) = 0 - Y
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1619 :
- ∀ (w : ℕ) (Y X : Bitvec w), X - Y - X = Bitvec.ofInt w 0 - Y
+ ∀ (w : ℕ) (Y X : Bitvec w), X - Y - X = 0 - Y
 := by alive_auto
       try sorry
 
@@ -128,8 +128,8 @@ theorem bitvec_AndOrXor_144 :
 
 theorem bitvec_AndOrXor_698 :
  ∀ (w : ℕ) (a b d : Bitvec w),
-  Bitvec.ofBool (a &&& b == Bitvec.ofInt w 0) &&& Bitvec.ofBool (a &&& d == Bitvec.ofInt w 0) =
-    Bitvec.ofBool (a &&& (b ||| d) == Bitvec.ofInt w 0)
+  Bitvec.ofBool (a &&& b == 0) &&& Bitvec.ofBool (a &&& d == 0) =
+    Bitvec.ofBool (a &&& (b ||| d) == 0)
 := by alive_auto
       try sorry
 
@@ -154,8 +154,8 @@ theorem bitvec_AndOrXor_794 :
 
 theorem bitvec_AndOrXor_827 :
  ∀ (w : ℕ) (a b : Bitvec w),
-  Bitvec.ofBool (a == Bitvec.ofInt w 0) &&& Bitvec.ofBool (b == Bitvec.ofInt w 0) =
-    Bitvec.ofBool (a ||| b == Bitvec.ofInt w 0)
+  Bitvec.ofBool (a == 0) &&& Bitvec.ofBool (b == 0) =
+    Bitvec.ofBool (a ||| b == 0)
 := by alive_auto
       try sorry
 
@@ -166,37 +166,37 @@ theorem bitvec_AndOrXor_887_2 :
 
 theorem bitvec_AndOrXor_1230__A__B___A__B :
  ∀ (w : ℕ) (notOp0 notOp1 : Bitvec w),
-  (notOp0 ^^^ Bitvec.ofInt w (-1)) &&& (notOp1 ^^^ Bitvec.ofInt w (-1)) = (notOp0 ||| notOp1) ^^^ Bitvec.ofInt w (-1)
+  (notOp0 ^^^ (-1)) &&& (notOp1 ^^^ (-1)) = (notOp0 ||| notOp1) ^^^ (-1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1241_AB__AB__AB :
- ∀ (w : ℕ) (A B : Bitvec w), (A ||| B) &&& (A &&& B ^^^ Bitvec.ofInt w (-1)) = A ^^^ B
+ ∀ (w : ℕ) (A B : Bitvec w), (A ||| B) &&& (A &&& B ^^^ (-1)) = A ^^^ B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1247_AB__AB__AB :
- ∀ (w : ℕ) (A B : Bitvec w), (A &&& B ^^^ Bitvec.ofInt w (-1)) &&& (A ||| B) = A ^^^ B
+ ∀ (w : ℕ) (A B : Bitvec w), (A &&& B ^^^ (-1)) &&& (A ||| B) = A ^^^ B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1253_A__AB___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ B) &&& A = A &&& (B ^^^ Bitvec.ofInt w (-1))
+ ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ B) &&& A = A &&& (B ^^^ (-1))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1280_ABA___AB :
- ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ Bitvec.ofInt w (-1) ||| B) &&& A = A &&& B
+ ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ (-1) ||| B) &&& A = A &&& B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1288_A__B__B__C__A___A__B__C :
- ∀ (w : ℕ) (A C B : Bitvec w), (A ^^^ B) &&& (B ^^^ C ^^^ A) = (A ^^^ B) &&& (C ^^^ Bitvec.ofInt w (-1))
+ ∀ (w : ℕ) (A C B : Bitvec w), (A ^^^ B) &&& (B ^^^ C ^^^ A) = (A ^^^ B) &&& (C ^^^ (-1))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1294_A__B__A__B___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), (A ||| B) &&& (A ^^^ Bitvec.ofInt w (-1) ^^^ B) = A &&& B
+ ∀ (w : ℕ) (A B : Bitvec w), (A ||| B) &&& (A ^^^ (-1) ^^^ B) = A &&& B
 := by alive_auto
       try sorry
 
@@ -215,22 +215,22 @@ theorem bitvec_AndOrXor_1683_2 :
 
 theorem bitvec_AndOrXor_1704 :
  ∀ (w : ℕ) (A B : Bitvec w),
-  Bitvec.ofBool (B == Bitvec.ofInt w 0) ||| Bitvec.ofBool (decide (Bitvec.toNat A < Bitvec.toNat B)) =
-    Bitvec.ofBool (decide (Bitvec.toNat (B + Bitvec.ofInt w (-1)) ≥ Bitvec.toNat A))
+  Bitvec.ofBool (B == 0) ||| Bitvec.ofBool (decide (Bitvec.toNat A < Bitvec.toNat B)) =
+    Bitvec.ofBool (decide (Bitvec.toNat (B + (-1)) ≥ Bitvec.toNat A))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1705 :
  ∀ (w : ℕ) (A B : Bitvec w),
-  Bitvec.ofBool (B == Bitvec.ofInt w 0) ||| Bitvec.ofBool (decide (Bitvec.toNat B > Bitvec.toNat A)) =
-    Bitvec.ofBool (decide (Bitvec.toNat (B + Bitvec.ofInt w (-1)) ≥ Bitvec.toNat A))
+  Bitvec.ofBool (B == 0) ||| Bitvec.ofBool (decide (Bitvec.toNat B > Bitvec.toNat A)) =
+    Bitvec.ofBool (decide (Bitvec.toNat (B + (-1)) ≥ Bitvec.toNat A))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1733 :
  ∀ (w : ℕ) (A B : Bitvec w),
-  Bitvec.ofBool (A != Bitvec.ofInt w 0) ||| Bitvec.ofBool (B != Bitvec.ofInt w 0) =
-    Bitvec.ofBool (A ||| B != Bitvec.ofInt w 0)
+  Bitvec.ofBool (A != 0) ||| Bitvec.ofBool (B != 0) =
+    Bitvec.ofBool (A ||| B != 0)
 := by alive_auto
       try sorry
 
@@ -240,22 +240,22 @@ theorem bitvec_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
       try sorry
 
 theorem bitvec_AndOrXor_2113___A__B__A___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ Bitvec.ofInt w (-1)) &&& B ||| A = A ||| B
+ ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ (-1)) &&& B ||| A = A ||| B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2118___A__B__A___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), A &&& B ||| A ^^^ Bitvec.ofInt w (-1) = A ^^^ Bitvec.ofInt w (-1) ||| B
+ ∀ (w : ℕ) (A B : Bitvec w), A &&& B ||| A ^^^ (-1) = A ^^^ (-1) ||| B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2123___A__B__A__B___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), A &&& (B ^^^ Bitvec.ofInt w (-1)) ||| A ^^^ B = A ^^^ B
+ ∀ (w : ℕ) (A B : Bitvec w), A &&& (B ^^^ (-1)) ||| A ^^^ B = A ^^^ B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2188 :
- ∀ (w : ℕ) (A D : Bitvec w), A &&& (D ^^^ Bitvec.ofInt w (-1)) ||| (A ^^^ Bitvec.ofInt w (-1)) &&& D = A ^^^ D
+ ∀ (w : ℕ) (A D : Bitvec w), A &&& (D ^^^ (-1)) ||| (A ^^^ (-1)) &&& D = A ^^^ D
 := by alive_auto
       try sorry
 
@@ -270,7 +270,7 @@ theorem bitvec_AndOrXor_2243__B__C__A__B___B__A__C :
       try sorry
 
 theorem bitvec_AndOrXor_2247__A__B__A__B :
- ∀ (w : ℕ) (A B : Bitvec w), A ^^^ Bitvec.ofInt w (-1) ||| B ^^^ Bitvec.ofInt w (-1) = A &&& B ^^^ Bitvec.ofInt w (-1)
+ ∀ (w : ℕ) (A B : Bitvec w), A ^^^ (-1) ||| B ^^^ (-1) = A &&& B ^^^ (-1)
 := by alive_auto
       try sorry
 
@@ -280,7 +280,7 @@ theorem bitvec_AndOrXor_2263 :
       try sorry
 
 theorem bitvec_AndOrXor_2264 :
- ∀ (w : ℕ) (A B : Bitvec w), A ||| A ^^^ Bitvec.ofInt w (-1) ^^^ B = A ||| B ^^^ Bitvec.ofInt w (-1)
+ ∀ (w : ℕ) (A B : Bitvec w), A ||| A ^^^ (-1) ^^^ B = A ||| B ^^^ (-1)
 := by alive_auto
       try sorry
 
@@ -290,17 +290,17 @@ theorem bitvec_AndOrXor_2265 :
       try sorry
 
 theorem bitvec_AndOrXor_2284 :
- ∀ (w : ℕ) (A B : Bitvec w), A ||| (A ||| B) ^^^ Bitvec.ofInt w (-1) = A ||| B ^^^ Bitvec.ofInt w (-1)
+ ∀ (w : ℕ) (A B : Bitvec w), A ||| (A ||| B) ^^^ (-1) = A ||| B ^^^ (-1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2285 :
- ∀ (w : ℕ) (A B : Bitvec w), A ||| A ^^^ B ^^^ Bitvec.ofInt w (-1) = A ||| B ^^^ Bitvec.ofInt w (-1)
+ ∀ (w : ℕ) (A B : Bitvec w), A ||| A ^^^ B ^^^ (-1) = A ||| B ^^^ (-1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2297 :
- ∀ (w : ℕ) (A B : Bitvec w), A &&& B ||| A ^^^ Bitvec.ofInt w (-1) ^^^ B = A ^^^ Bitvec.ofInt w (-1) ^^^ B
+ ∀ (w : ℕ) (A B : Bitvec w), A &&& B ||| A ^^^ (-1) ^^^ B = A ^^^ (-1) ^^^ B
 := by alive_auto
       try sorry
 
@@ -311,57 +311,57 @@ theorem bitvec_AndOrXor_2367 :
 
 theorem bitvec_AndOrXor_2416 :
  ∀ (w : ℕ) (nx y : Bitvec w),
-  (nx ^^^ Bitvec.ofInt w (-1)) &&& y ^^^ Bitvec.ofInt w (-1) = nx ||| y ^^^ Bitvec.ofInt w (-1)
+  (nx ^^^ (-1)) &&& y ^^^ (-1) = nx ||| y ^^^ (-1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2417 :
  ∀ (w : ℕ) (nx y : Bitvec w),
-  (nx ^^^ Bitvec.ofInt w (-1) ||| y) ^^^ Bitvec.ofInt w (-1) = nx &&& (y ^^^ Bitvec.ofInt w (-1))
+  (nx ^^^ (-1) ||| y) ^^^ (-1) = nx &&& (y ^^^ (-1))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2429 :
- ∀ (w : ℕ) (y x : Bitvec w), x &&& y ^^^ Bitvec.ofInt w (-1) = x ^^^ Bitvec.ofInt w (-1) ||| y ^^^ Bitvec.ofInt w (-1)
+ ∀ (w : ℕ) (y x : Bitvec w), x &&& y ^^^ (-1) = x ^^^ (-1) ||| y ^^^ (-1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2430 :
  ∀ (w : ℕ) (y x : Bitvec w),
-  (x ||| y) ^^^ Bitvec.ofInt w (-1) = (x ^^^ Bitvec.ofInt w (-1)) &&& (y ^^^ Bitvec.ofInt w (-1))
+  (x ||| y) ^^^ (-1) = (x ^^^ (-1)) &&& (y ^^^ (-1))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2443 :
  ∀ (w : ℕ) (y x : Bitvec w),
-  Bitvec.sshr (x ^^^ Bitvec.ofInt w (-1)) (Bitvec.toNat y) ^^^ Bitvec.ofInt w (-1) = Bitvec.sshr x (Bitvec.toNat y)
+  Bitvec.sshr (x ^^^ (-1)) (Bitvec.toNat y) ^^^ (-1) = Bitvec.sshr x (Bitvec.toNat y)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2453 :
  ∀ (w : ℕ) (y x : Bitvec w),
-  Bitvec.ofBool (decide (Bitvec.toInt x < Bitvec.toInt y)) ^^^ Bitvec.ofInt 1 (-1) =
+  Bitvec.ofBool (decide (Bitvec.toInt x < Bitvec.toInt y)) ^^^ (-1) =
     Bitvec.ofBool (decide (Bitvec.toInt x ≥ Bitvec.toInt y))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2475 :
- ∀ (w : ℕ) (x C : Bitvec w), C - x ^^^ Bitvec.ofInt w (-1) = x + (Bitvec.ofInt w (-1) - C)
+ ∀ (w : ℕ) (x C : Bitvec w), C - x ^^^ (-1) = x + ((-1) - C)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2486 :
- ∀ (w : ℕ) (x C : Bitvec w), x + C ^^^ Bitvec.ofInt w (-1) = Bitvec.ofInt w (-1) - C - x
+ ∀ (w : ℕ) (x C : Bitvec w), x + C ^^^ (-1) = (-1) - C - x
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2581__BAB___A__B :
- ∀ (w : ℕ) (a op1 : Bitvec w), (a ||| op1) ^^^ op1 = a &&& (op1 ^^^ Bitvec.ofInt w (-1))
+ ∀ (w : ℕ) (a op1 : Bitvec w), (a ||| op1) ^^^ op1 = a &&& (op1 ^^^ (-1))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2587__BAA___B__A :
- ∀ (w : ℕ) (a op1 : Bitvec w), a &&& op1 ^^^ op1 = (a ^^^ Bitvec.ofInt w (-1)) &&& op1
+ ∀ (w : ℕ) (a op1 : Bitvec w), a &&& op1 ^^^ op1 = (a ^^^ (-1)) &&& op1
 := by alive_auto
       try sorry
 
@@ -371,17 +371,17 @@ theorem bitvec_AndOrXor_2595 :
       try sorry
 
 theorem bitvec_AndOrXor_2607 :
- ∀ (w : ℕ) (a b : Bitvec w), (a ||| b ^^^ Bitvec.ofInt w (-1)) ^^^ (a ^^^ Bitvec.ofInt w (-1) ||| b) = a ^^^ b
+ ∀ (w : ℕ) (a b : Bitvec w), (a ||| b ^^^ (-1)) ^^^ (a ^^^ (-1) ||| b) = a ^^^ b
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2617 :
- ∀ (w : ℕ) (a b : Bitvec w), a &&& (b ^^^ Bitvec.ofInt w (-1)) ^^^ (a ^^^ Bitvec.ofInt w (-1)) &&& b = a ^^^ b
+ ∀ (w : ℕ) (a b : Bitvec w), a &&& (b ^^^ (-1)) ^^^ (a ^^^ (-1)) &&& b = a ^^^ b
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2627 :
- ∀ (w : ℕ) (a c b : Bitvec w), a ^^^ c ^^^ (a ||| b) = (a ^^^ Bitvec.ofInt w (-1)) &&& b ^^^ c
+ ∀ (w : ℕ) (a c b : Bitvec w), a ^^^ c ^^^ (a ||| b) = (a ^^^ (-1)) &&& b ^^^ c
 := by alive_auto
       try sorry
 
@@ -392,7 +392,7 @@ theorem bitvec_AndOrXor_2647 :
 
 theorem bitvec_AndOrXor_2658 :
  ∀ (w : ℕ) (a b : Bitvec w),
-  a &&& (b ^^^ Bitvec.ofInt w (-1)) ^^^ (a ^^^ Bitvec.ofInt w (-1)) = a &&& b ^^^ Bitvec.ofInt w (-1)
+  a &&& (b ^^^ (-1)) ^^^ (a ^^^ (-1)) = a &&& b ^^^ (-1)
 := by alive_auto
       try sorry
 
@@ -404,7 +404,7 @@ theorem bitvec_AndOrXor_2663 :
       try sorry
 
 theorem bitvec_152 :
- ∀ (w : ℕ) (x : Bitvec w), x * Bitvec.ofInt w (-1) = Bitvec.ofInt w 0 - x
+ ∀ (w : ℕ) (x : Bitvec w), x * (-1) = 0 - x
 := by alive_auto
       try sorry
 
@@ -419,7 +419,7 @@ theorem bitvec_229 :
       try sorry
 
 theorem bitvec_239 :
- ∀ (w : ℕ) (Y X : Bitvec w), (Bitvec.ofInt w 0 - X) * (Bitvec.ofInt w 0 - Y) = X * Y
+ ∀ (w : ℕ) (Y X : Bitvec w), (0 - X) * (0 - Y) = X * Y
 := by alive_auto
       try sorry
 
@@ -435,13 +435,13 @@ theorem bitvec_265_2 :
 
 theorem bitvec_266 :
  ∀ (w : ℕ) (Y X : Bitvec w),
-  (Option.bind (Bitvec.udiv? X Y) fun fst => some (fst * (Bitvec.ofInt w 0 - Y))) ⊑ some (Bitvec.ofInt w 0 - X)
+  (Option.bind (Bitvec.udiv? X Y) fun fst => some (fst * (0 - Y))) ⊑ some (0 - X)
 := by alive_auto
       try sorry
 
 theorem bitvec_266_2 :
  ∀ (w : ℕ) (Y X : Bitvec w),
-  (Option.bind (Bitvec.sdiv? X Y) fun fst => some (fst * (Bitvec.ofInt w 0 - Y))) ⊑ some (Bitvec.ofInt w 0 - X)
+  (Option.bind (Bitvec.sdiv? X Y) fun fst => some (fst * (0 - Y))) ⊑ some (0 - X)
 := by alive_auto
       try sorry
 
@@ -459,14 +459,14 @@ theorem bitvec_275_2:
 
 theorem bitvec_276:
  ∀ (Y X : Bitvec 5),
-  (Option.bind (Bitvec.sdiv? X Y) fun fst => some (fst * (Bitvec.ofInt 5 0 - Y))) ⊑
+  (Option.bind (Bitvec.sdiv? X Y) fun fst => some (fst * (0 - Y))) ⊑
     Option.bind (Bitvec.urem? X Y) fun fst => some (fst - X)
 := by alive_auto
       try sorry
 
 theorem bitvec_276_2:
  ∀ (Y X : Bitvec 5),
-  (Option.bind (Bitvec.udiv? X Y) fun fst => some (fst * (Bitvec.ofInt 5 0 - Y))) ⊑
+  (Option.bind (Bitvec.udiv? X Y) fun fst => some (fst * (0 - Y))) ⊑
     Option.bind (Bitvec.urem? X Y) fun fst => some (fst - X)
 := by alive_auto
       try sorry
@@ -477,7 +477,7 @@ theorem bitvec_283:
       try sorry
 
 theorem bitvec_290__292 :
- ∀ (w : ℕ) (Y Op1 : Bitvec w), Bitvec.ofInt w 1 <<< Y * Op1 = Op1 <<< Y
+ ∀ (w : ℕ) (Y Op1 : Bitvec w), 1 <<< Y * Op1 = Op1 <<< Y
 := by alive_auto
       try sorry
 
@@ -496,22 +496,22 @@ theorem bitvec_820':
       try sorry
 
 theorem bitvec_891:
- ∀ (x N : Bitvec 13), Bitvec.udiv? x (Bitvec.ofInt 13 1 <<< N) ⊑ some (x >>> N)
+ ∀ (x N : Bitvec 13), Bitvec.udiv? x (1 <<< N) ⊑ some (x >>> N)
 := by alive_auto
       try sorry
 
 theorem bitvec_891_exact:
- ∀ (x N : Bitvec 13), Bitvec.udiv? x (Bitvec.ofInt 13 1 <<< N) ⊑ some (x >>> N)
+ ∀ (x N : Bitvec 13), Bitvec.udiv? x (1 <<< N) ⊑ some (x >>> N)
 := by alive_auto
       try sorry
 
 theorem bitvec_1030 :
- ∀ (w : ℕ) (X : Bitvec w), Bitvec.sdiv? X (Bitvec.ofInt w (-1)) ⊑ some (Bitvec.ofInt w 0 - X)
+ ∀ (w : ℕ) (X : Bitvec w), Bitvec.sdiv? X ((-1)) ⊑ some (0 - X)
 := by alive_auto
       try sorry
 
 theorem bitvec_1049:
- ∀ (X C : Bitvec 11), Bitvec.sdiv? (Bitvec.ofInt 11 0 - X) C ⊑ Bitvec.sdiv? X (-C)
+ ∀ (X C : Bitvec 11), Bitvec.sdiv? (0 - X) C ⊑ Bitvec.sdiv? X (-C)
 := by alive_auto
       try sorry
 
@@ -556,12 +556,12 @@ theorem bitvec_Select_1105 :
       try sorry
 
 theorem bitvec_InstCombineShift__239 :
- ∀ (w : ℕ) (X C : Bitvec w), X <<< C >>> C = X &&& Bitvec.ofInt w (-1) >>> C
+ ∀ (w : ℕ) (X C : Bitvec w), X <<< C >>> C = X &&& (-1) >>> C
 := by alive_auto
       try sorry
 
 theorem bitvec_InstCombineShift__279 :
- ∀ (w : ℕ) (X C : Bitvec w), X >>> C <<< C = X &&& Bitvec.ofInt w (-1) <<< C
+ ∀ (w : ℕ) (X C : Bitvec w), X >>> C <<< C = X &&& (-1) <<< C
 := by alive_auto
       try sorry
 
@@ -571,12 +571,12 @@ theorem bitvec_InstCombineShift__351:
       try sorry
 
 theorem bitvec_InstCombineShift__422_1:
- ∀ (Y X C : Bitvec 31), (Y + X >>> C) <<< C = Y <<< C + X &&& Bitvec.ofInt 31 (-1) <<< C
+ ∀ (Y X C : Bitvec 31), (Y + X >>> C) <<< C = Y <<< C + X &&& (-1) <<< C
 := by alive_auto
       try sorry
 
 theorem bitvec_InstCombineShift__422_2:
- ∀ (Y X C : Bitvec 31), (Y + Bitvec.sshr X (Bitvec.toNat C)) <<< C = Y <<< C + X &&& Bitvec.ofInt 31 (-1) <<< C
+ ∀ (Y X C : Bitvec 31), (Y + Bitvec.sshr X (Bitvec.toNat C)) <<< C = Y <<< C + X &&& (-1) <<< C
 := by alive_auto
       try sorry
 
@@ -586,7 +586,7 @@ theorem bitvec_InstCombineShift__440 :
       try sorry
 
 theorem bitvec_InstCombineShift__458:
- ∀ (Y X C : Bitvec 31), (Bitvec.sshr X (Bitvec.toNat C) - Y) <<< C = X - Y <<< C &&& Bitvec.ofInt 31 (-1) <<< C
+ ∀ (Y X C : Bitvec 31), (Bitvec.sshr X (Bitvec.toNat C) - Y) <<< C = X - Y <<< C &&& (-1) <<< C
 := by alive_auto
       try sorry
 
@@ -606,7 +606,7 @@ theorem bitvec_InstCombineShift__497''' :
       try sorry
 
 theorem bitvec_InstCombineShift__582 :
- ∀ (w : ℕ) (X C : Bitvec w), X <<< C >>> C = X &&& Bitvec.ofInt w (-1) >>> C
+ ∀ (w : ℕ) (X C : Bitvec w), X <<< C >>> C = X &&& (-1) >>> C
 := by alive_auto
       try sorry
 

--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -42,7 +42,7 @@ theorem bitvec_AddSub_1176 :
       try sorry
 
 theorem bitvec_AddSub_1202 :
- ∀ (w : ℕ) (x C : Bitvec w), (x ^^^ (-1)) + C = C - 1 - x
+ ∀ (w : ℕ) (x C : Bitvec w), (x ^^^ -1) + C = C - 1 - x
 := by alive_auto
       try sorry
 
@@ -87,12 +87,12 @@ theorem bitvec_AddSub_1556:
       try sorry
 
 theorem bitvec_AddSub_1560 :
- ∀ (w : ℕ) (a : Bitvec w), (-1) - a = a ^^^ (-1)
+ ∀ (w : ℕ) (a : Bitvec w), -1 - a = a ^^^ -1
 := by alive_auto
       try sorry
 
 theorem bitvec_AddSub_1564 :
- ∀ (w : ℕ) (x C : Bitvec w), C - (x ^^^ (-1)) = x + (C + 1)
+ ∀ (w : ℕ) (x C : Bitvec w), C - (x ^^^ -1) = x + (C + 1)
 := by alive_auto
       try sorry
 
@@ -128,8 +128,7 @@ theorem bitvec_AndOrXor_144 :
 
 theorem bitvec_AndOrXor_698 :
  ∀ (w : ℕ) (a b d : Bitvec w),
-  Bitvec.ofBool (a &&& b == 0) &&& Bitvec.ofBool (a &&& d == 0) =
-    Bitvec.ofBool (a &&& (b ||| d) == 0)
+  Bitvec.ofBool (a &&& b == 0) &&& Bitvec.ofBool (a &&& d == 0) = Bitvec.ofBool (a &&& (b ||| d) == 0)
 := by alive_auto
       try sorry
 
@@ -153,9 +152,7 @@ theorem bitvec_AndOrXor_794 :
       try sorry
 
 theorem bitvec_AndOrXor_827 :
- ∀ (w : ℕ) (a b : Bitvec w),
-  Bitvec.ofBool (a == 0) &&& Bitvec.ofBool (b == 0) =
-    Bitvec.ofBool (a ||| b == 0)
+ ∀ (w : ℕ) (a b : Bitvec w), Bitvec.ofBool (a == 0) &&& Bitvec.ofBool (b == 0) = Bitvec.ofBool (a ||| b == 0)
 := by alive_auto
       try sorry
 
@@ -165,38 +162,37 @@ theorem bitvec_AndOrXor_887_2 :
       try sorry
 
 theorem bitvec_AndOrXor_1230__A__B___A__B :
- ∀ (w : ℕ) (notOp0 notOp1 : Bitvec w),
-  (notOp0 ^^^ (-1)) &&& (notOp1 ^^^ (-1)) = (notOp0 ||| notOp1) ^^^ (-1)
+ ∀ (w : ℕ) (notOp0 notOp1 : Bitvec w), (notOp0 ^^^ -1) &&& (notOp1 ^^^ -1) = (notOp0 ||| notOp1) ^^^ -1
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1241_AB__AB__AB :
- ∀ (w : ℕ) (A B : Bitvec w), (A ||| B) &&& (A &&& B ^^^ (-1)) = A ^^^ B
+ ∀ (w : ℕ) (A B : Bitvec w), (A ||| B) &&& (A &&& B ^^^ -1) = A ^^^ B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1247_AB__AB__AB :
- ∀ (w : ℕ) (A B : Bitvec w), (A &&& B ^^^ (-1)) &&& (A ||| B) = A ^^^ B
+ ∀ (w : ℕ) (A B : Bitvec w), (A &&& B ^^^ -1) &&& (A ||| B) = A ^^^ B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1253_A__AB___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ B) &&& A = A &&& (B ^^^ (-1))
+ ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ B) &&& A = A &&& (B ^^^ -1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1280_ABA___AB :
- ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ (-1) ||| B) &&& A = A &&& B
+ ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ -1 ||| B) &&& A = A &&& B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1288_A__B__B__C__A___A__B__C :
- ∀ (w : ℕ) (A C B : Bitvec w), (A ^^^ B) &&& (B ^^^ C ^^^ A) = (A ^^^ B) &&& (C ^^^ (-1))
+ ∀ (w : ℕ) (A C B : Bitvec w), (A ^^^ B) &&& (B ^^^ C ^^^ A) = (A ^^^ B) &&& (C ^^^ -1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1294_A__B__A__B___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), (A ||| B) &&& (A ^^^ (-1) ^^^ B) = A &&& B
+ ∀ (w : ℕ) (A B : Bitvec w), (A ||| B) &&& (A ^^^ -1 ^^^ B) = A &&& B
 := by alive_auto
       try sorry
 
@@ -216,21 +212,19 @@ theorem bitvec_AndOrXor_1683_2 :
 theorem bitvec_AndOrXor_1704 :
  ∀ (w : ℕ) (A B : Bitvec w),
   Bitvec.ofBool (B == 0) ||| Bitvec.ofBool (decide (Bitvec.toNat A < Bitvec.toNat B)) =
-    Bitvec.ofBool (decide (Bitvec.toNat (B + (-1)) ≥ Bitvec.toNat A))
+    Bitvec.ofBool (decide (Bitvec.toNat (B + -1) ≥ Bitvec.toNat A))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1705 :
  ∀ (w : ℕ) (A B : Bitvec w),
   Bitvec.ofBool (B == 0) ||| Bitvec.ofBool (decide (Bitvec.toNat B > Bitvec.toNat A)) =
-    Bitvec.ofBool (decide (Bitvec.toNat (B + (-1)) ≥ Bitvec.toNat A))
+    Bitvec.ofBool (decide (Bitvec.toNat (B + -1) ≥ Bitvec.toNat A))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_1733 :
- ∀ (w : ℕ) (A B : Bitvec w),
-  Bitvec.ofBool (A != 0) ||| Bitvec.ofBool (B != 0) =
-    Bitvec.ofBool (A ||| B != 0)
+ ∀ (w : ℕ) (A B : Bitvec w), Bitvec.ofBool (A != 0) ||| Bitvec.ofBool (B != 0) = Bitvec.ofBool (A ||| B != 0)
 := by alive_auto
       try sorry
 
@@ -240,22 +234,22 @@ theorem bitvec_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
       try sorry
 
 theorem bitvec_AndOrXor_2113___A__B__A___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ (-1)) &&& B ||| A = A ||| B
+ ∀ (w : ℕ) (A B : Bitvec w), (A ^^^ -1) &&& B ||| A = A ||| B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2118___A__B__A___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), A &&& B ||| A ^^^ (-1) = A ^^^ (-1) ||| B
+ ∀ (w : ℕ) (A B : Bitvec w), A &&& B ||| A ^^^ -1 = A ^^^ -1 ||| B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2123___A__B__A__B___A__B :
- ∀ (w : ℕ) (A B : Bitvec w), A &&& (B ^^^ (-1)) ||| A ^^^ B = A ^^^ B
+ ∀ (w : ℕ) (A B : Bitvec w), A &&& (B ^^^ -1) ||| A ^^^ B = A ^^^ B
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2188 :
- ∀ (w : ℕ) (A D : Bitvec w), A &&& (D ^^^ (-1)) ||| (A ^^^ (-1)) &&& D = A ^^^ D
+ ∀ (w : ℕ) (A D : Bitvec w), A &&& (D ^^^ -1) ||| (A ^^^ -1) &&& D = A ^^^ D
 := by alive_auto
       try sorry
 
@@ -270,7 +264,7 @@ theorem bitvec_AndOrXor_2243__B__C__A__B___B__A__C :
       try sorry
 
 theorem bitvec_AndOrXor_2247__A__B__A__B :
- ∀ (w : ℕ) (A B : Bitvec w), A ^^^ (-1) ||| B ^^^ (-1) = A &&& B ^^^ (-1)
+ ∀ (w : ℕ) (A B : Bitvec w), A ^^^ -1 ||| B ^^^ -1 = A &&& B ^^^ -1
 := by alive_auto
       try sorry
 
@@ -280,7 +274,7 @@ theorem bitvec_AndOrXor_2263 :
       try sorry
 
 theorem bitvec_AndOrXor_2264 :
- ∀ (w : ℕ) (A B : Bitvec w), A ||| A ^^^ (-1) ^^^ B = A ||| B ^^^ (-1)
+ ∀ (w : ℕ) (A B : Bitvec w), A ||| A ^^^ -1 ^^^ B = A ||| B ^^^ -1
 := by alive_auto
       try sorry
 
@@ -290,17 +284,17 @@ theorem bitvec_AndOrXor_2265 :
       try sorry
 
 theorem bitvec_AndOrXor_2284 :
- ∀ (w : ℕ) (A B : Bitvec w), A ||| (A ||| B) ^^^ (-1) = A ||| B ^^^ (-1)
+ ∀ (w : ℕ) (A B : Bitvec w), A ||| (A ||| B) ^^^ -1 = A ||| B ^^^ -1
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2285 :
- ∀ (w : ℕ) (A B : Bitvec w), A ||| A ^^^ B ^^^ (-1) = A ||| B ^^^ (-1)
+ ∀ (w : ℕ) (A B : Bitvec w), A ||| A ^^^ B ^^^ -1 = A ||| B ^^^ -1
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2297 :
- ∀ (w : ℕ) (A B : Bitvec w), A &&& B ||| A ^^^ (-1) ^^^ B = A ^^^ (-1) ^^^ B
+ ∀ (w : ℕ) (A B : Bitvec w), A &&& B ||| A ^^^ -1 ^^^ B = A ^^^ -1 ^^^ B
 := by alive_auto
       try sorry
 
@@ -310,58 +304,54 @@ theorem bitvec_AndOrXor_2367 :
       try sorry
 
 theorem bitvec_AndOrXor_2416 :
- ∀ (w : ℕ) (nx y : Bitvec w),
-  (nx ^^^ (-1)) &&& y ^^^ (-1) = nx ||| y ^^^ (-1)
+ ∀ (w : ℕ) (nx y : Bitvec w), (nx ^^^ -1) &&& y ^^^ -1 = nx ||| y ^^^ -1
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2417 :
- ∀ (w : ℕ) (nx y : Bitvec w),
-  (nx ^^^ (-1) ||| y) ^^^ (-1) = nx &&& (y ^^^ (-1))
+ ∀ (w : ℕ) (nx y : Bitvec w), (nx ^^^ -1 ||| y) ^^^ -1 = nx &&& (y ^^^ -1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2429 :
- ∀ (w : ℕ) (y x : Bitvec w), x &&& y ^^^ (-1) = x ^^^ (-1) ||| y ^^^ (-1)
+ ∀ (w : ℕ) (y x : Bitvec w), x &&& y ^^^ -1 = x ^^^ -1 ||| y ^^^ -1
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2430 :
- ∀ (w : ℕ) (y x : Bitvec w),
-  (x ||| y) ^^^ (-1) = (x ^^^ (-1)) &&& (y ^^^ (-1))
+ ∀ (w : ℕ) (y x : Bitvec w), (x ||| y) ^^^ -1 = (x ^^^ -1) &&& (y ^^^ -1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2443 :
- ∀ (w : ℕ) (y x : Bitvec w),
-  Bitvec.sshr (x ^^^ (-1)) (Bitvec.toNat y) ^^^ (-1) = Bitvec.sshr x (Bitvec.toNat y)
+ ∀ (w : ℕ) (y x : Bitvec w), Bitvec.sshr (x ^^^ -1) (Bitvec.toNat y) ^^^ -1 = Bitvec.sshr x (Bitvec.toNat y)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2453 :
  ∀ (w : ℕ) (y x : Bitvec w),
-  Bitvec.ofBool (decide (Bitvec.toInt x < Bitvec.toInt y)) ^^^ (-1) =
+  Bitvec.ofBool (decide (Bitvec.toInt x < Bitvec.toInt y)) ^^^ -1 =
     Bitvec.ofBool (decide (Bitvec.toInt x ≥ Bitvec.toInt y))
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2475 :
- ∀ (w : ℕ) (x C : Bitvec w), C - x ^^^ (-1) = x + ((-1) - C)
+ ∀ (w : ℕ) (x C : Bitvec w), C - x ^^^ -1 = x + (-1 - C)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2486 :
- ∀ (w : ℕ) (x C : Bitvec w), x + C ^^^ (-1) = (-1) - C - x
+ ∀ (w : ℕ) (x C : Bitvec w), x + C ^^^ -1 = -1 - C - x
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2581__BAB___A__B :
- ∀ (w : ℕ) (a op1 : Bitvec w), (a ||| op1) ^^^ op1 = a &&& (op1 ^^^ (-1))
+ ∀ (w : ℕ) (a op1 : Bitvec w), (a ||| op1) ^^^ op1 = a &&& (op1 ^^^ -1)
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2587__BAA___B__A :
- ∀ (w : ℕ) (a op1 : Bitvec w), a &&& op1 ^^^ op1 = (a ^^^ (-1)) &&& op1
+ ∀ (w : ℕ) (a op1 : Bitvec w), a &&& op1 ^^^ op1 = (a ^^^ -1) &&& op1
 := by alive_auto
       try sorry
 
@@ -371,17 +361,17 @@ theorem bitvec_AndOrXor_2595 :
       try sorry
 
 theorem bitvec_AndOrXor_2607 :
- ∀ (w : ℕ) (a b : Bitvec w), (a ||| b ^^^ (-1)) ^^^ (a ^^^ (-1) ||| b) = a ^^^ b
+ ∀ (w : ℕ) (a b : Bitvec w), (a ||| b ^^^ -1) ^^^ (a ^^^ -1 ||| b) = a ^^^ b
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2617 :
- ∀ (w : ℕ) (a b : Bitvec w), a &&& (b ^^^ (-1)) ^^^ (a ^^^ (-1)) &&& b = a ^^^ b
+ ∀ (w : ℕ) (a b : Bitvec w), a &&& (b ^^^ -1) ^^^ (a ^^^ -1) &&& b = a ^^^ b
 := by alive_auto
       try sorry
 
 theorem bitvec_AndOrXor_2627 :
- ∀ (w : ℕ) (a c b : Bitvec w), a ^^^ c ^^^ (a ||| b) = (a ^^^ (-1)) &&& b ^^^ c
+ ∀ (w : ℕ) (a c b : Bitvec w), a ^^^ c ^^^ (a ||| b) = (a ^^^ -1) &&& b ^^^ c
 := by alive_auto
       try sorry
 
@@ -391,8 +381,7 @@ theorem bitvec_AndOrXor_2647 :
       try sorry
 
 theorem bitvec_AndOrXor_2658 :
- ∀ (w : ℕ) (a b : Bitvec w),
-  a &&& (b ^^^ (-1)) ^^^ (a ^^^ (-1)) = a &&& b ^^^ (-1)
+ ∀ (w : ℕ) (a b : Bitvec w), a &&& (b ^^^ -1) ^^^ (a ^^^ -1) = a &&& b ^^^ -1
 := by alive_auto
       try sorry
 
@@ -404,7 +393,7 @@ theorem bitvec_AndOrXor_2663 :
       try sorry
 
 theorem bitvec_152 :
- ∀ (w : ℕ) (x : Bitvec w), x * (-1) = 0 - x
+ ∀ (w : ℕ) (x : Bitvec w), x * -1 = 0 - x
 := by alive_auto
       try sorry
 
@@ -434,14 +423,12 @@ theorem bitvec_265_2 :
       try sorry
 
 theorem bitvec_266 :
- ∀ (w : ℕ) (Y X : Bitvec w),
-  (Option.bind (Bitvec.udiv? X Y) fun fst => some (fst * (0 - Y))) ⊑ some (0 - X)
+ ∀ (w : ℕ) (Y X : Bitvec w), (Option.bind (Bitvec.udiv? X Y) fun fst => some (fst * (0 - Y))) ⊑ some (0 - X)
 := by alive_auto
       try sorry
 
 theorem bitvec_266_2 :
- ∀ (w : ℕ) (Y X : Bitvec w),
-  (Option.bind (Bitvec.sdiv? X Y) fun fst => some (fst * (0 - Y))) ⊑ some (0 - X)
+ ∀ (w : ℕ) (Y X : Bitvec w), (Option.bind (Bitvec.sdiv? X Y) fun fst => some (fst * (0 - Y))) ⊑ some (0 - X)
 := by alive_auto
       try sorry
 
@@ -506,7 +493,7 @@ theorem bitvec_891_exact:
       try sorry
 
 theorem bitvec_1030 :
- ∀ (w : ℕ) (X : Bitvec w), Bitvec.sdiv? X ((-1)) ⊑ some (0 - X)
+ ∀ (w : ℕ) (X : Bitvec w), Bitvec.sdiv? X (-1) ⊑ some (0 - X)
 := by alive_auto
       try sorry
 

--- a/SSA/Projects/InstCombine/Broken.lean
+++ b/SSA/Projects/InstCombine/Broken.lean
@@ -89,7 +89,7 @@ theorem alive_SimplifyDivRemOfSelect : forall (w : Nat) (Y X c : Bitvec 1)
   %v0 := unit: ;
   %v1 := op:const (c) %v0;
   %v2 := op:const (Y) %v0;
-  %v3 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v3 := op:const (0) %v0;
   %v4 := triple:%v1 %v2 %v3;
   %v5 := op:select w %v4;
   %v6 := op:const (X) %v0;
@@ -105,7 +105,7 @@ theorem alive_SimplifyDivRemOfSelect : forall (w : Nat) (Y X c : Bitvec 1)
   %v0 := unit: ;
   %v1 := op:const (c) %v0;
   %v2 := op:const (Y) %v0;
-  %v3 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v3 := op:const (0) %v0;
   %v4 := triple:%v1 %v2 %v3;
   %v5 := op:select 1 %v4;
   %v6 := op:const (X) %v0;
@@ -136,7 +136,7 @@ theorem alive_805 : forall (w : Nat) (X : Bitvec 1)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v1 := op:const (1) %v0;
   %v2 := op:const (X) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sdiv w %v3
@@ -149,13 +149,13 @@ theorem alive_805 : forall (w : Nat) (X : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (X) %v0;
-  %v2 := op:const (Bitvec.ofInt w (1)) %v0;
+  %v2 := op:const (1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:add w %v3;
   %v5 := op:const (Bitvec.ofInt w (3)) %v0;
   %v6 := pair:%v4 %v5;
   %v7 := op:icmp ult  w %v6;
-  %v8 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := triple:%v7 %v1 %v8;
   %v10 := op:select w %v9
   dsl_ret %v10
@@ -514,18 +514,18 @@ theorem alive_Select_740 : forall (w : Nat) (A : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp sgt  w %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:sub 1 %v6;
   %v8 := triple:%v4 %v1 %v7;
   %v9 := op:select w %v8;
-  %v10 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v10 := op:const (-1) %v0;
   %v11 := pair:%v9 %v10;
   %v12 := op:icmp sgt  w %v11;
-  %v13 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v13 := op:const (0) %v0;
   %v14 := pair:%v13 %v9;
   %v15 := op:sub w %v14;
   %v16 := triple:%v12 %v9 %v15;
@@ -539,18 +539,18 @@ theorem alive_Select_740 : forall (w : Nat) (A : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp sgt  1 %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:sub 1 %v6;
   %v8 := triple:%v4 %v1 %v7;
   %v9 := op:select 1 %v8;
-  %v10 := op:const (Bitvec.ofInt 1 (-1)) %v0;
+  %v10 := op:const (-1) %v0;
   %v11 := pair:%v9 %v10;
   %v12 := op:icmp sgt  1 %v11;
-  %v13 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v13 := op:const (0) %v0;
   %v14 := pair:%v13 %v9;
   %v15 := op:sub 1 %v14;
   %v16 := triple:%v4 %v1 %v7;
@@ -589,18 +589,18 @@ theorem alive_Select_741 : forall (w : Nat) (A : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp sgt  w %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:sub 1 %v6;
   %v8 := triple:%v4 %v7 %v1;
   %v9 := op:select w %v8;
-  %v10 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v10 := op:const (-1) %v0;
   %v11 := pair:%v9 %v10;
   %v12 := op:icmp sgt  w %v11;
-  %v13 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v13 := op:const (0) %v0;
   %v14 := pair:%v13 %v9;
   %v15 := op:sub w %v14;
   %v16 := triple:%v12 %v15 %v9;
@@ -614,18 +614,18 @@ theorem alive_Select_741 : forall (w : Nat) (A : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp sgt  1 %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:sub 1 %v6;
   %v8 := triple:%v4 %v7 %v1;
   %v9 := op:select 1 %v8;
-  %v10 := op:const (Bitvec.ofInt 1 (-1)) %v0;
+  %v10 := op:const (-1) %v0;
   %v11 := pair:%v9 %v10;
   %v12 := op:icmp sgt  1 %v11;
-  %v13 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v13 := op:const (0) %v0;
   %v14 := pair:%v13 %v9;
   %v15 := op:sub 1 %v14;
   %v16 := triple:%v4 %v7 %v1;
@@ -665,18 +665,18 @@ theorem alive_Select_746 : forall (w : Nat) (A : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp slt  w %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:sub 1 %v6;
   %v8 := triple:%v4 %v1 %v7;
   %v9 := op:select w %v8;
-  %v10 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v10 := op:const (0) %v0;
   %v11 := pair:%v9 %v10;
   %v12 := op:icmp sgt  w %v11;
-  %v13 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v13 := op:const (0) %v0;
   %v14 := pair:%v13 %v9;
   %v15 := op:sub w %v14;
   %v16 := triple:%v12 %v9 %v15;
@@ -689,22 +689,22 @@ theorem alive_Select_746 : forall (w : Nat) (A : Bitvec 1)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (A) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub 1 %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v2 %v5;
   %v7 := op:icmp sgt  1 %v6;
-  %v8 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := pair:%v2 %v8;
   %v10 := op:icmp slt  1 %v9;
   %v11 := triple:%v10 %v2 %v4;
   %v12 := op:select 1 %v11;
-  %v13 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v13 := op:const (0) %v0;
   %v14 := pair:%v12 %v13;
   %v15 := op:icmp sgt  1 %v14;
-  %v16 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v16 := op:const (0) %v0;
   %v17 := pair:%v16 %v12;
   %v18 := op:sub 1 %v17;
   %v19 := triple:%v7 %v2 %v4;
@@ -744,18 +744,18 @@ theorem alive_Select_747 : forall (w : Nat) (A : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (A) %v0;
-  %v2 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v2 := op:const (0) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:icmp sgt  w %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v5 %v1;
   %v7 := op:sub 1 %v6;
   %v8 := triple:%v4 %v1 %v7;
   %v9 := op:select w %v8;
-  %v10 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v10 := op:const (0) %v0;
   %v11 := pair:%v9 %v10;
   %v12 := op:icmp slt  w %v11;
-  %v13 := op:const (Bitvec.ofInt w (0)) %v0;
+  %v13 := op:const (0) %v0;
   %v14 := pair:%v13 %v9;
   %v15 := op:sub w %v14;
   %v16 := triple:%v12 %v9 %v15;
@@ -768,22 +768,22 @@ theorem alive_Select_747 : forall (w : Nat) (A : Bitvec 1)
   [dsl_bb|
   ^bb
   %v0 := unit: ;
-  %v1 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v1 := op:const (0) %v0;
   %v2 := op:const (A) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:sub 1 %v3;
-  %v5 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v5 := op:const (0) %v0;
   %v6 := pair:%v2 %v5;
   %v7 := op:icmp slt  1 %v6;
-  %v8 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v8 := op:const (0) %v0;
   %v9 := pair:%v2 %v8;
   %v10 := op:icmp sgt  1 %v9;
   %v11 := triple:%v10 %v2 %v4;
   %v12 := op:select 1 %v11;
-  %v13 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v13 := op:const (0) %v0;
   %v14 := pair:%v12 %v13;
   %v15 := op:icmp slt  1 %v14;
-  %v16 := op:const (Bitvec.ofInt 1 (0)) %v0;
+  %v16 := op:const (0) %v0;
   %v17 := pair:%v16 %v12;
   %v18 := op:sub 1 %v17;
   %v19 := triple:%v7 %v2 %v4;
@@ -814,7 +814,7 @@ theorem alive_Select_858 : forall (w : Nat) (a b : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (b) %v0;
@@ -829,7 +829,7 @@ theorem alive_Select_858 : forall (w : Nat) (a b : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt 1 (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor 1 %v3;
   %v5 := op:const (b) %v0;
@@ -861,7 +861,7 @@ theorem alive_Select_859' : forall (w : Nat) (a b : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt w (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor w %v3;
   %v5 := op:const (b) %v0;
@@ -876,7 +876,7 @@ theorem alive_Select_859' : forall (w : Nat) (a b : Bitvec 1)
   ^bb
   %v0 := unit: ;
   %v1 := op:const (a) %v0;
-  %v2 := op:const (Bitvec.ofInt 1 (-1)) %v0;
+  %v2 := op:const (-1) %v0;
   %v3 := pair:%v1 %v2;
   %v4 := op:xor 1 %v3;
   %v5 := op:const (b) %v0;

--- a/SSA/Projects/InstCombine/splitandprocess.py
+++ b/SSA/Projects/InstCombine/splitandprocess.py
@@ -14,7 +14,7 @@ def getProofs(lines):
     return proofs[0], proofs[1:]
 
 def isWorkingProof(preamble, proof):
-    f = open("InstCombineAliveTest.lean", "w")
+    f = open("AliveTest.lean", "w")
 
     f.write("".join(preamble))
     rewritten = []
@@ -25,7 +25,7 @@ def isWorkingProof(preamble, proof):
     f.close()
     
     import subprocess
-    x = subprocess.run("(cd ../../../; lake build SSA.Projects.InstCombine.InstCombineAliveTest)", shell=True, capture_output=True)
+    x = subprocess.run("(cd ../../../; lake build SSA.Projects.InstCombine.AliveTest)", shell=True, capture_output=True)
     return (x.returncode == 0 or x.stderr.decode().find("no goals to be solved") != -1)
 
 def filterProofs(preamble, proofs):
@@ -47,9 +47,9 @@ def writeOutput(preamble, proofs, filename):
         for proof in proofs:
             f.write("".join(proof))
 
-f = open("InstCombineAliveAll.lean", "r")
+f = open("AliveAll.lean", "r")
 lines = f.readlines()
 preamble, proofs = getProofs(lines)
 working_proofs, broken_proofs = filterProofs(preamble, proofs)
-writeOutput(preamble, working_proofs, "InstCombineAlive.lean")
+writeOutput(preamble, working_proofs, "Alive.lean")
 writeOutput(preamble, broken_proofs, "Broken.lean")


### PR DESCRIPTION
**Before**
```lean
 ∀ (w : ℕ) (a b : Bitvec w), a + (Bitvec.ofInt w 0 - b) = a - b
 ∀ (w : ℕ) (x C : Bitvec w), (x ^^^ Bitvec.ofInt w (-1)) + C = C - Bitvec.ofInt w 1 - x
```
**After**
```
 ∀ (w : ℕ) (a b : Bitvec w), a + (0 - b) = a - b
 ∀ (w : ℕ) (x C : Bitvec w), (x ^^^ -1) + C = C - 1 - x
```
We can already use 0/1/-1 in theorem statements, and the theorems still compile.

The only problems is ` ∀ (w : ℕ) (b : Bitvec w), b + b = Bitvec.shl b (Bitvec.toNat (Bitvec.ofInt w 1))`, which must be turned into ` ∀ (w : ℕ) (b : Bitvec w), b + b = Bitvec.shl b 1`.

Finally, it seems this change starts to break some proofs. This might be interesting to investigate.