### PR TITLE
Remove expr rec

### DIFF
--- a/SSA/Experimental/Bugred/failed-to-generate-splitter-2.lean
+++ b/SSA/Experimental/Bugred/failed-to-generate-splitter-2.lean
@@ -1,0 +1,81 @@
+import Mathlib.Data.Erased
+
+inductive Ty
+  | nat
+
+def Ctxt : Type :=
+  Erased <| List Ty
+  
+noncomputable def Ctxt.snoc (Γ : Ctxt) (t : Ty) : Ctxt :=
+  Erased.mk <| t :: Γ.out
+
+def Ctxt.Var (Γ : Ctxt) (t : Ty) : Type :=
+  { i : Nat // Γ.out.get? i = some t }  
+
+inductive CtxtProp : Ctxt → Type
+  | nil : CtxtProp (Erased.mk [])
+  | snoc : CtxtProp Δ → CtxtProp (Δ.snoc t)
+
+
+noncomputable def matchVar {t : Ty} {Δ : Ctxt} : CtxtProp Δ → Δ.Var t → Option Bool
+  | .snoc d, ⟨w+1, h⟩ => -- w† = Var.toSnoc w
+      let w : Ctxt.Var _ t := ⟨w, by simp_all[List.get?, Ctxt.snoc]⟩
+      matchVar d w
+  -- Neither spelling out all cases, nor having a single fallback case work
+  | .snoc _, ⟨0, _⟩ | .nil, ⟨0, _⟩ | .nil, ⟨_+1, h⟩ => none
+  -- | _, _ => none
+
+
+example {Δ : Ctxt} (d : CtxtProp Δ) {w : Δ.Var t} : 
+  matchVar d w = none
+    := by
+        unfold matchVar /- throws error:
+          failed to generate splitter for match auxiliary declaration 'matchVar.match_1', unsolved subgoal:
+            case x
+            t: Ty
+            motive: (Δ : Ctxt) → CtxtProp Δ → Ctxt.Var Δ t → Sort u_1
+            h_1: (Γ : Ctxt) →
+              (t_2 : Ty) →
+                (d : CtxtProp Γ) →
+                  (w : ℕ) →
+                    (h : List.get? (Erased.out (Ctxt.snoc Γ t_2)) (w + 1) = some t) →
+                      motive (Ctxt.snoc Γ t_2) (CtxtProp.snoc d) { val := Nat.succ w, property := h }
+            h_2: (Γ : Ctxt) →
+              (t_2 : Ty) →
+                (a : CtxtProp Γ) →
+                  (property : List.get? (Erased.out (Ctxt.snoc Γ t_2)) 0 = some t) →
+                    (∀ (Γ_1 : Ctxt) (t_1 : Ty) (d : CtxtProp Γ_1) (w : ℕ)
+                        (h : List.get? (Erased.out (Ctxt.snoc Γ_1 t_1)) (w + 1) = some t),
+                        ((fun b => t_2 :: Erased.out Γ = b) = fun b => t_1 :: Erased.out Γ_1 = b) →
+                          HEq (_ : ∃ a, (fun b => a = b) = fun b => t_2 :: Erased.out Γ = b)
+                              (_ : ∃ a, (fun b => a = b) = fun b => t_1 :: Erased.out Γ_1 = b) →
+                            HEq (CtxtProp.snoc a) (CtxtProp.snoc d) →
+                              HEq { val := 0, property := property } { val := Nat.succ w, property := h } → False) →
+                      motive (Ctxt.snoc Γ t_2) (CtxtProp.snoc a) { val := 0, property := property }
+            h_3: (property : List.get? (Erased.out (Erased.mk [])) 0 = some t) →
+              motive (Erased.mk []) CtxtProp.nil { val := 0, property := property }
+            h_4: (n : ℕ) →
+              (h : List.get? (Erased.out (Erased.mk [])) (n + 1) = some t) →
+                motive (Erased.mk []) CtxtProp.nil { val := Nat.succ n, property := h }
+            Δ✝: Ctxt
+            t✝: Ty
+            a✝: CtxtProp Δ✝
+            x✝²: Ctxt.Var (Ctxt.snoc Δ✝ t✝) t
+            val✝: ℕ
+            property✝¹: List.get? (Erased.out (Ctxt.snoc Δ✝ t✝)) val✝ = some t
+            property✝: List.get? (Erased.out (Ctxt.snoc Δ✝ t✝)) Nat.zero = some t
+            Γ: Ctxt
+            t_1: Ty
+            d: CtxtProp Γ
+            w: ℕ
+            h: List.get? (Erased.out (Ctxt.snoc Γ t_1)) (w + 1) = some t
+            fst_eq: (fun b => t✝ :: Erased.out Δ✝ = b) = fun b => t_1 :: Erased.out Γ = b
+            snd_eq: HEq (_ : ∃ a, (fun b => a = b) = fun b => t✝ :: Erased.out Δ✝ = b)
+              (_ : ∃ a, (fun b => a = b) = fun b => t_1 :: Erased.out Γ = b)
+            x_1: HEq (CtxtProp.snoc a✝) (CtxtProp.snoc d)
+            x_2: HEq { val := 0, property := property✝ } { val := Nat.succ w, property := h }
+            x✝¹: CtxtProp (Ctxt.snoc Δ✝ t✝)
+            x✝: Ctxt.Var (Ctxt.snoc Δ✝ t✝) t
+            ⊢ False
+        -/
+        sorry

--- a/SSA/Experimental/Bugred/failed-to-generate-splitter.lean
+++ b/SSA/Experimental/Bugred/failed-to-generate-splitter.lean
@@ -1,0 +1,40 @@
+/-!
+  This file was originally intended to showcase a `failed to generate splitter` error.
+  In the process of minimization, that error dissapeared.
+  Instead, we triggered an infinite loop
+-/
+
+
+inductive Ty
+  | nat
+
+def Ctxt : Type :=
+  List Ty
+
+def Ctxt.Var (Γ : Ctxt) (t : Ty) : Type :=
+  { i : Nat // Γ.get? i = some t }  
+
+
+inductive Lets : Ctxt → Ctxt → Type where
+  | nil : Lets Γ Γ
+  | lete (body : Lets Γ₁ Γ₂) (t : Ty)  : Lets Γ₁ (t :: Γ₂)
+
+
+def matchVar (t : Ty) (matchLets : Lets Δ_in Δ_out) (w : Δ_out.Var t)  : 
+    Option Bool := 
+  match matchLets, w with
+    | .lete matchLets _, ⟨w+1, h⟩ => -- w† = Var.toSnoc w
+        let w := ⟨w, by simp_all[List.get?]⟩
+        matchVar t matchLets w
+    | _, _ => do
+        none
+
+
+example {Δ : Ctxt } 
+  {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t} {w : Δ.Var t} : 
+  matchVar t .nil w = none
+    := by
+        -- uncommenting the `unfold` triggers an infinite loop of sorts, 
+        -- consuming 100% CPU without being caught by `maxHeartbeats` timeout
+        -- unfold matchVar
+        sorry

--- a/SSA/Experimental/Bugred/failed-to-generate-splitter.lean
+++ b/SSA/Experimental/Bugred/failed-to-generate-splitter.lean
@@ -5,28 +5,21 @@
 -/
 
 
-
 inductive Ty
   | nat
 
 def Ctxt : Type :=
   List Ty
-
-def Ctxt.Var.IsValid (Γ : Ctxt) (t : Ty) (i : Nat) : Prop :=
-  Γ.get? i = some t
+  
 
 def Ctxt.Var (Γ : Ctxt) (t : Ty) : Type :=
-  { i : Nat // Var.IsValid Γ t i }  
-
-def Ctxt.Var.IsValid.ofSucc :
-    IsValid (u :: Γ) t (i+1) → IsValid Γ t i := by
-  simp[IsValid, List.get?]
-  exact id
+  { i : Nat // Γ.get? i = some t }  
 
 
 def matchVar {t : Ty} : {Δ : Ctxt} → Δ.Var t → Option Bool 
-  | _::_, ⟨w+1, h⟩ => -- w† = Var.toSnoc w
-      matchVar ⟨w, .ofSucc h⟩
+  | _::Δ, ⟨w+1, h⟩ => -- w† = Var.toSnoc w
+      let w : Ctxt.Var Δ t := ⟨w, by simp_all[List.get?]⟩
+      matchVar w
   | _, _ =>
       none
 

--- a/SSA/Experimental/ErasedContext.lean
+++ b/SSA/Experimental/ErasedContext.lean
@@ -32,6 +32,7 @@ instance : DecidableEq (Var Γ t) := by
   delta Var
   infer_instance
 
+@[match_pattern]
 def last (Γ : Ctxt) (t : Ty) : Ctxt.Var (Ctxt.snoc Γ t) t :=
   ⟨0, by simp [snoc, List.get?]⟩
 

--- a/SSA/Experimental/ErasedContext.lean
+++ b/SSA/Experimental/ErasedContext.lean
@@ -65,6 +65,11 @@ theorem zero_eq_last {Γ : Ctxt} {t : Ty} (h) :
     ⟨0, h⟩ = last Γ t :=
   rfl
 
+@[simp]
+theorem succ_eq_toSnoc {Γ : Ctxt} {t : Ty} {w} (h : (Γ.snoc t).get? (w+1) = some t') :
+    ⟨w+1, h⟩ = toSnoc ⟨w, h⟩ :=
+  rfl
+
 
   
 /-- This is an induction principle that case splits on whether or not a variable 

--- a/SSA/Experimental/ErasedContext.lean
+++ b/SSA/Experimental/ErasedContext.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Erased
+import Mathlib.Data.Finset.Basic
 
 /-- A very simple type universe. -/
 inductive Ty
@@ -26,6 +27,12 @@ instance : EmptyCollection Ctxt := ⟨Ctxt.empty⟩
 def snoc : Ctxt → Ty → Ctxt :=
   -- fun tl hd => do return hd :: (← tl)
   fun tl hd => hd :: tl
+
+/-- Turn a list of types into a context -/
+@[coe, simp]
+def ofList : List Ty → Ctxt :=
+  -- Erased.mk
+  fun Γ => Γ 
   
 
 def Var (Γ : Ctxt) (t : Ty) : Type :=
@@ -148,5 +155,29 @@ theorem Valuation.snoc_last {Γ : Ctxt} {t : Ty} (s : Γ.Valuation) (x : t.toTyp
 theorem Valuation.snoc_toSnoc {Γ : Ctxt} {t t' : Ty} (s : Γ.Valuation) (x : t.toType) 
     (v : Γ.Var t') : (s.snoc x) v.toSnoc = s v := by
   simp [Ctxt.Valuation.snoc]
+
+
+
+/- ## VarSet -/
+
+/-- A `Ty`-indexed family of sets of variables in context `Γ` -/
+def VarSet (Γ : Ctxt) : Type := 
+  (t' : Ty) → Finset (Γ.Var t')
+
+namespace VarSet
+
+/-- A `VarSet` with exactly one variable `v` -/
+@[simp]
+def ofVar {Γ : Ctxt} (v : Γ.Var t) : VarSet Γ :=
+  fun t' => if ty_eq : t = t' then {ty_eq ▸ v} else {}
+
+@[simp]
+instance : EmptyCollection (VarSet Γ) := ⟨fun _ => ∅⟩
+
+@[simp]
+instance : Union (VarSet Γ) := ⟨fun S₁ S₂ t => S₁ t ∪ S₂ t⟩
+
+end VarSet
+
 
 end Ctxt

--- a/SSA/Experimental/ErasedContext.lean
+++ b/SSA/Experimental/ErasedContext.lean
@@ -12,19 +12,24 @@ def Ty.toType
   | bool => Bool
 
 def Ctxt : Type :=
-  Erased <| List Ty
+  -- Erased <| List Ty
+  List Ty
 
 namespace Ctxt
 
-def empty : Ctxt := Erased.mk []
+-- def empty : Ctxt := Erased.mk []
+def empty : Ctxt := []
 
 instance : EmptyCollection Ctxt := ⟨Ctxt.empty⟩
 
 def snoc : Ctxt → Ty → Ctxt :=
-  fun tl hd => do return hd :: (← tl)
+  -- fun tl hd => do return hd :: (← tl)
+  fun tl hd => hd :: tl
+  
 
 def Var (Γ : Ctxt) (t : Ty) : Type :=
-  { i : Nat // Γ.out.get? i = some t }
+  -- { i : Nat // Γ.out.get? i = some t }
+  { i : Nat // Γ.get? i = some t }
 
 namespace Var
 

--- a/SSA/Experimental/ErasedContext.lean
+++ b/SSA/Experimental/ErasedContext.lean
@@ -22,6 +22,7 @@ def empty : Ctxt := []
 
 instance : EmptyCollection Ctxt := ⟨Ctxt.empty⟩
 
+@[match_pattern]
 def snoc : Ctxt → Ty → Ctxt :=
   -- fun tl hd => do return hd :: (← tl)
   fun tl hd => hd :: tl
@@ -51,6 +52,13 @@ in context `Γ.snoc t`. This is marked as a coercion. -/
 @[coe]
 def toSnoc {Γ : Ctxt} {t t' : Ty} (var : Var Γ t) : Var (snoc Γ t') t  :=
   ⟨var.1+1, by cases var; simp_all [snoc]⟩
+
+@[simp]
+theorem zero_eq_last {Γ : Ctxt} {t : Ty} (h) :
+    ⟨0, h⟩ = last Γ t :=
+  rfl
+
+
   
 /-- This is an induction principle that case splits on whether or not a variable 
 is the last variable in a context. -/

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -9,6 +9,9 @@ import Mathlib.Tactic.Ring
 
 open Ctxt (Var VarSet)
 
+/- 
+  # Datastructures 
+-/
 
 /-- A very simple intrinsically typed expression. -/
 inductive IExpr : Ctxt → Ty → Type
@@ -29,7 +32,9 @@ inductive Lets : Ctxt → Ctxt → Type where
 
 
 
-
+/- 
+  # Definitions
+-/
 
 def IExpr.denote : IExpr Γ ty → (Γv : Γ.Valuation) → ty.toType
   | .cst n, _ => n
@@ -140,8 +145,6 @@ theorem denote_addProgramToLets_var {lets : Lets Γ_in Γ_out} {map} {com : ICom
     cases v using Ctxt.Var.casesOn
     . rfl
     . simp [Lets.denote]; rfl
-    
-
 
 /-- Add some `Lets` to the beginning of a program -/
 def addLetsAtTop {Γ₁ Γ₂ : Ctxt} :
@@ -306,7 +309,11 @@ theorem Lets.denote_getIExpr {Γ₁ Γ₂ : Ctxt} : {lets : Lets Γ₁ Γ₂} �
   . contradiction
   . rw[←Option.some_inj.mp he, denote_getIExprAux]
 
-  
+
+
+/-
+  ## Matching
+-/  
 
 abbrev Mapping (Γ Δ : Ctxt) : Type :=
   @AList (Σ t, Γ.Var t) (fun x => Δ.Var x.1)
@@ -321,35 +328,33 @@ def Lets.vars : Lets Γ_in Γ_out → Γ_out.Var t → Γ_in.VarSet
         | .cst _    => ∅ 
         | .add x y  => lets.vars x ∪ lets.vars y
 
--- theorem Lets.denote_eq_of_eq_on_vars (lets : Lets Γ_in Γ_out) (v : Γ_out.Var t)
---     {s₁ s₂ : Γ_in.Valuation} 
---     (h : ∀ t w, w ∈ lets.vars v t → s₁ w = s₂ w) :
---     lets.denote s₁ v = lets.denote s₂ v := by
---   induction lets
---   next => 
---     simp [vars] at h
---     simp [denote, h _ v]
---   next lets e ih =>
---     cases v using Ctxt.Var.casesOn
---     . simp [vars] at h
---       simp[denote]
---       apply ih _ h
---     . simp [denote, IExpr.denote]
---       cases e
---       . simp [vars] at h
---         simp
---         congr 1
---         <;> apply ih
---         <;> intro _ _ hw
---         <;> apply h
---         . apply Or.inl hw
---         . apply Or.inr hw
---       . simp
+theorem Lets.denote_eq_of_eq_on_vars (lets : Lets Γ_in Γ_out) (v : Γ_out.Var t)
+    {s₁ s₂ : Γ_in.Valuation} 
+    (h : ∀ t w, w ∈ lets.vars v t → s₁ w = s₂ w) :
+    lets.denote s₁ v = lets.denote s₂ v := by
+  induction lets
+  next => 
+    simp [vars] at h
+    simp [denote, h _ v]
+  next lets e ih =>
+    cases v using Ctxt.Var.casesOn
+    . simp [vars] at h
+      simp[denote]
+      apply ih _ h
+    . simp [denote, IExpr.denote]
+      cases e
+      . simp [vars] at h
+        simp
+        congr 1
+        <;> apply ih
+        <;> intro _ _ hw
+        <;> apply h
+        . apply Or.inl hw
+        . apply Or.inr hw
+      . simp
 
 def ICom.vars : ICom Γ t → Γ.VarSet :=
   fun com => com.toLets.lets.vars com.toLets.ret
-
-
 
 /-- 
   Given two sequences of lets, `lets` and `matchExpr`, 
@@ -710,6 +715,12 @@ theorem denote_splitProgramAt {pos : ℕ} {prog : ICom Γ₁ t}
     res.2.2.1.denote (res.2.1.denote s) = prog.denote s :=
   denote_splitProgramAtAux hres s
 
+
+
+/-
+  ## Rewriting
+-/
+
 /-- `rewriteAt lhs rhs hlhs pos target`, searches for `lhs` at position `pos` of
 `target`. If it can match the variables, it inserts `rhs` into the program
 with the correct assignment of variables, and then replaces occurences
@@ -806,6 +817,12 @@ theorem denote_rewritePeepholeAt (pr : PeepholeRewrite Γ t)
           apply denote_rewriteAt pr.lhs pr.rhs h pos target pr.correct _ hrew
         | none => simp
     case neg h => simp
+
+
+
+/-
+  ## Examples
+-/
 
 macro "simp_peephole": tactic =>
   `(tactic|

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -343,6 +343,30 @@ def matchVar {Γ_in Γ_out Δ_in Δ_out : Ctxt} {t : Ty}
 #check Lets.brecOn
 #print matchVar
 
+example {Δ : Ctxt } 
+  {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t} {w : Δ.Var t}
+  {ma : Mapping Δ Γ_out} : 
+  matchVar lets v Lets.nil w ma = 
+    match ma.lookup ⟨_, w⟩ with
+      | some v₂ =>
+        by
+          exact if v = v₂
+            then some ma
+            else none
+      | none => some (AList.insert ⟨_, w⟩ v ma)  
+    := by
+  rfl
+
+example {Δ : Ctxt } 
+  {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t} 
+  {matchLets : Lets Δ_in Δ_out} {matchE : IExpr Δ_out d}
+  {ma : Mapping Δ_in Γ_out} : 
+  matchVar lets v (Lets.lete matchLets matchE) ⟨w+1, h⟩ ma = 
+    let w := ⟨w, by simp_all[Ctxt.snoc]⟩
+    matchVar lets v matchLets w ma
+    := by
+  rfl
+
 open AList
 
 /-- For mathlib -/
@@ -365,8 +389,8 @@ theorem subset_entries_matchVar :
     {w : Δ_out.Var t} →
     (hvarMap : varMap ∈ matchVar lets v matchLets w ma) → 
     ma.entries ⊆ varMap.entries 
-  | Γ₁, _, Γ₃, t, varMap, ma, lets, v, .nil, v' => by
-    simp only [matchVar, Option.mem_def]
+  | Γ₁, _, Γ₃, t, varMap, ma, lets, v, .nil, w => by
+    unfold matchVar
     intros h x hx
     split at h
     . split_ifs at h

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -183,40 +183,6 @@ theorem denote_addProgramInMiddle {Γ₁ Γ₂ Γ₃ : Ctxt}
   rw [addProgramInMiddle, denote_addLetsAtTop, Function.comp_apply, 
     denote_addProgramAtTop]
 
--- /-- Substitute each free variable in an `ExprRec` for another `ExprRec` 
--- in a different context. -/
--- def ExprRec.bind {Γ₁ Γ₂ : Ctxt} 
---     (f : (t : Ty) → Γ₁.Var t → ExprRec Γ₂ t) : 
---     (e : ExprRec Γ₁ t) → ExprRec Γ₂ t
---   | .var v => f _ v
---   | .cst n => .cst n
---   | .add e₁ e₂ => .add (bind f e₁) (bind f e₂)
-
--- @[simp]
--- theorem ExprRec.denote_bind {Γ₁ Γ₂ : Ctxt} (s : Γ₂.Valuation) 
---     (f : (t : Ty) → Γ₁.Var t → ExprRec Γ₂ t) :
---     (e : ExprRec Γ₁ t) → (e.bind f).denote s = 
---       e.denote (fun t' v' => (f t' v').denote s)
---   | .var v => by simp [bind, denote]
---   | .cst n => by simp [bind, denote]
---   | .add e₁ e₂ => by
---     simp only [ExprRec.denote, bind]
---     rw [denote_bind _ _ e₁, denote_bind _ _ e₂]
-
--- def IExpr.toExprRec : {Γ : Ctxt} → {t : Ty} → IExpr Γ t → ExprRec Γ t
---   | _, _, .cst n => .cst n
---   | _, _, .add e₁ e₂ => .add (.var e₁) (.var e₂)
-
--- def ICom.toExprRec : {Γ : Ctxt} → {t : Ty} → ICom Γ t → ExprRec Γ t
---   | _, _, .ret e => .var e
---   | _, _, .lete e body => 
---     let e' := e.toExprRec
---     body.toExprRec.bind 
---     (fun t v => by
---       cases v using Ctxt.Var.casesOn with
---       | toSnoc v => exact .var v
---       | last => exact e')
-
 structure FlatICom (Γ : Ctxt) (t : Ty) where
   {Γ_out : Ctxt}
   /-- The let bindings of the original program -/

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -260,6 +260,7 @@ def Lets.getIExprAuxDiff {lets : Lets Γ₁ Γ₂} {v : Γ₂.Var t}
       simp only [getIExprAux, eq_rec_constant] at h  
       cases v using Ctxt.Var.casesOn <;> simp at h
       . intro h'
+        simp [Ctxt.get?]
         simp[←ih h h', Ctxt.snoc, Ctxt.Var.toSnoc, List.get?]
       . rcases h with ⟨⟨⟩, ⟨⟩⟩
         simp[Ctxt.snoc, List.get?, Ctxt.Var.last]
@@ -320,30 +321,30 @@ def Lets.vars : Lets Γ_in Γ_out → Γ_out.Var t → Γ_in.VarSet
         | .cst _    => ∅ 
         | .add x y  => lets.vars x ∪ lets.vars y
 
-theorem Lets.denote_eq_of_eq_on_vars (lets : Lets Γ_in Γ_out) (v : Γ_out.Var t)
-    {s₁ s₂ : Γ_in.Valuation} 
-    (h : ∀ t w, w ∈ lets.vars v t → s₁ w = s₂ w) :
-    lets.denote s₁ v = lets.denote s₂ v := by
-  induction lets
-  next => 
-    simp [vars] at h
-    simp [denote, h _ v]
-  next lets e ih =>
-    cases v using Ctxt.Var.casesOn
-    . simp [vars] at h
-      simp[denote]
-      apply ih _ h
-    . simp [denote, IExpr.denote]
-      cases e
-      . simp [vars] at h
-        simp
-        congr 1
-        <;> apply ih
-        <;> intro _ _ hw
-        <;> apply h
-        . apply Or.inl hw
-        . apply Or.inr hw
-      . simp
+-- theorem Lets.denote_eq_of_eq_on_vars (lets : Lets Γ_in Γ_out) (v : Γ_out.Var t)
+--     {s₁ s₂ : Γ_in.Valuation} 
+--     (h : ∀ t w, w ∈ lets.vars v t → s₁ w = s₂ w) :
+--     lets.denote s₁ v = lets.denote s₂ v := by
+--   induction lets
+--   next => 
+--     simp [vars] at h
+--     simp [denote, h _ v]
+--   next lets e ih =>
+--     cases v using Ctxt.Var.casesOn
+--     . simp [vars] at h
+--       simp[denote]
+--       apply ih _ h
+--     . simp [denote, IExpr.denote]
+--       cases e
+--       . simp [vars] at h
+--         simp
+--         congr 1
+--         <;> apply ih
+--         <;> intro _ _ hw
+--         <;> apply h
+--         . apply Or.inl hw
+--         . apply Or.inr hw
+--       . simp
 
 def ICom.vars : ICom Γ t → Γ.VarSet :=
   fun com => com.toLets.lets.vars com.toLets.ret
@@ -524,7 +525,7 @@ theorem denote_matchVar_sub {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t}
     split at h_mv <;> try contradiction
     next e h_getIExpr =>
       simp only [h_getIExpr, bind_pure, Option.mem_def] at h_mv
-      rw [Lets.denote_getIExpr h_getIExpr]
+      rw [←Lets.denote_getIExpr h_getIExpr]
       simp only [IExpr.denote, Lets.denote, Ctxt.Var.casesOn_last, eq_rec_constant]
       split at h_mv <;> try contradiction
       next =>

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -777,12 +777,9 @@ theorem denote_rewritePeepholeAt (pr : PeepholeRewrite Γ t)
 macro "simp_peephole": tactic =>
   `(tactic|
       (
-      funext;
-      -- rw [←ICom.denote_toExprRec];
-      -- rw [←ICom.denote_toExprRec];
-      simp only [ExprRec.bind, IExpr.toExprRec, ExprRec.denote, ICom.toExprRec];
-      funext;
-      rename_i ll;
+      funext ll
+      simp only [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
+        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc]
       generalize ll { val := 0, property := _ } = a;
       generalize ll { val := 1, property := _ } = b;
       generalize ll { val := 2, property := _ } = c;

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -400,8 +400,8 @@ theorem _root_.AList.mem_of_mem_entries {α : Type _} {β : α → Type _} {s : 
     ⟨k, v⟩ ∈ s.entries → k ∈ s := by
   intro h
   rcases s with ⟨entries, nd⟩
-  simp [(· ∈ ·), keys] at h |-
-  clear nd;
+  simp [(· ∈ ·), keys] at h ⊢ 
+  clear nd
   induction h
   next    => apply List.Mem.head
   next ih => apply List.Mem.tail _ ih
@@ -410,7 +410,7 @@ theorem _root_.AList.mem_entries_of_mem {α : Type _} {β : α → Type _} {s : 
     k ∈ s → ∃ v, ⟨k, v⟩ ∈ s.entries := by
   intro h
   rcases s with ⟨entries, nd⟩
-  simp [(· ∈ ·), keys, List.keys] at h |-
+  simp [(· ∈ ·), keys, List.keys] at h ⊢ 
   clear nd;
   induction entries
   next    => contradiction
@@ -422,13 +422,6 @@ theorem _root_.AList.mem_entries_of_mem {α : Type _} {β : α → Type _} {s : 
     next h =>
       rcases ih h with ⟨v, ih⟩
       exact ⟨v, .tail _ ih⟩
-
-theorem _root_.AList.keys_subset_keys_of_entries_subset_entries 
-    {α : Type _} {β : α → Type _} 
-    {s₁ s₂ : AList β} (h : s₁.entries ⊆ s₂.entries) : s₁.keys ⊆ s₂.keys := by
-  intro k hk
-  rcases mem_entries_of_mem hk with ⟨v, he⟩
-  apply mem_of_mem_entries <| h he
 
 
 /-- The output mapping of `matchVar` extends the input mapping when it succeeds. -/
@@ -485,7 +478,8 @@ theorem subset_entries_matchVar {varMap : Mapping Δ_in Γ_out} {ma : Mapping Δ
 instance (t : Ty) : Inhabited t.toType := by
   cases t <;> dsimp [Ty.toType] <;> infer_instance
 
-theorem denote_matchVar_sub {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t} 
+theorem denote_matchVar_of_subset 
+    {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t} 
     {varMap₁ varMap₂ : Mapping Δ_in Γ_out}
     {s₁ : Γ_in.Valuation} 
     {ma : Mapping Δ_in Γ_out} :
@@ -520,7 +514,7 @@ theorem denote_matchVar_sub {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t}
       simp only [insert_entries, List.find?, List.mem_cons, true_or]
   | .lete matchLets _, ⟨w+1, h⟩ => by
     simp [matchVar]
-    apply denote_matchVar_sub
+    apply denote_matchVar_of_subset
   | .lete matchLets matchExpr, ⟨0, h_w⟩ => by
     rename_i t'
     have : t = t' := by simp[List.get?] at h_w; apply h_w.symm
@@ -548,7 +542,8 @@ theorem denote_matchVar_sub {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t}
             injection h_mv with h_mv
             subst h_mv
             simp [Lets.denote, Ctxt.Var.casesOn, IExpr.denote]
-            rw [denote_matchVar_sub h_matchVar₂ h_sub, denote_matchVar_sub h_matchVar₁]
+            rw [denote_matchVar_of_subset h_matchVar₂ h_sub, 
+                denote_matchVar_of_subset h_matchVar₁]
             . intro x hx
               apply h_sub
               apply subset_entries_matchVar h_matchVar₂
@@ -566,7 +561,7 @@ theorem denote_matchVar {lets : Lets Γ_in Γ_out} {v : Γ_out.Var t} {varMap : 
         | none => exact default 
         ) w = 
       lets.denote s₁ v :=
-  fun h => denote_matchVar_sub h (fun _ => id)
+  fun h => denote_matchVar_of_subset h (fun _ => id)
 
 /-- All variables containing in `matchExpr` are assigned by `matchVar`. -/
 theorem mem_matchVar 

--- a/SSA/Projects/InstCombine/ForMathlib.lean
+++ b/SSA/Projects/InstCombine/ForMathlib.lean
@@ -390,8 +390,8 @@ theorem get?_shl (x : Bitvec n) (i j : ℕ) :
       else none := by
   unfold shl
   rcases x with ⟨x, rfl⟩
-  simp only [toList_cong, Vector.toList_append, Vector.toList_drop, Vector.toList_mk, Bool.forall_bool,
-    add_eq_zero, and_imp, Vector.replicate]
+  simp only [Vector.shiftLeftFill, Vector.congr, Vector.append, Vector.drop, 
+    Vector.replicate, ge_iff_le, Vector.toList_mk]
   split_ifs with h₁ h₂
   { rw [List.get?_append, List.get?_drop]
     . rw [List.length_drop]
@@ -411,8 +411,8 @@ theorem get?_ushr (x : Bitvec n) (i j : ℕ) :
       else none := by
   unfold ushr
   rcases x with ⟨x, rfl⟩
-  simp only [fillShr, Vector.replicate, ge_iff_le, toList_cong, Vector.toList_append, 
-    Vector.toList_mk, Vector.toList_take, Bool.forall_bool, tsub_eq_zero_iff_le]
+  simp only [Vector.shiftRightFill, Vector.congr, Vector.append, 
+    Vector.replicate, ge_iff_le, Vector.take, Vector.toList_mk]
   split_ifs with h₁ h₂
   { rw [List.get?_append, List.get?_eq_get, List.get_replicate]
     . simp [*] at *

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,9 +4,9 @@
  [{"git":
    {"url": "https://github.com/EdAyers/ProofWidgets4",
     "subDir?": null,
-    "rev": "c43db94a8f495dad37829e9d7ad65483d68c86b8",
+    "rev": "a0c2cd0ac3245a0dade4f925bcfa97e06dd84229",
     "name": "proofwidgets",
-    "inputRev?": "v0.0.11"}},
+    "inputRev?": "v0.0.13"}},
   {"git":
    {"url": "https://github.com/mhuisi/lean4-cli.git",
     "subDir?": null,
@@ -16,24 +16,24 @@
   {"git":
    {"url": "https://github.com/leanprover-community/mathlib4",
     "subDir?": null,
-    "rev": "738e46a7f794a16ad6854afa7c7f3d2d502e248c",
+    "rev": "d08d8bb218e6354e222f30b54af3faf1260cdd90",
     "name": "mathlib",
-    "inputRev?": "738e46a7f794a16ad6854afa7c7f3d2d502e248c"}},
+    "inputRev?": "d08d8bb218e6354e222f30b54af3faf1260cdd90"}},
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "ae84bd82cca324dc958583d6f1ae08429877dcb0",
+    "rev": "81cc13c524a68d0072561dbac276cd61b65872a6",
     "name": "Qq",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "f04538ab6ad07642368cf11d2702acc0a9b4bcee",
+    "rev": "d13a9666e6f430b940ef8d092f1219e964b52a09",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "dff883c55395438ae2a5c65ad5ddba084b600feb",
+    "rev": "dbffa8cb31b0c51b151453c4ff8f00ede2a84ed8",
     "name": "std",
     "inputRev?": "main"}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -37,7 +37,7 @@ lean_exe mlirnatural {
 
 -- NOTE: this must be 'm'mathlib, as indicated from:
 --  https://github.com/leanprover-community/mathlib4#using-mathlib4-as-a-dependency
-require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "738e46a7f794a16ad6854afa7c7f3d2d502e248c"
+require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "d08d8bb218e6354e222f30b54af3faf1260cdd90"
 
 require Cli from git "https://github.com/mhuisi/lean4-cli.git" @ "nightly"
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,2 @@
-leanprover/lean4:nightly-2023-07-12
+leanprover/lean4:nightly-2023-08-05
+


### PR DESCRIPTION
Express the match pattern for `matchVar` as a sequence of lets (i.e., `Lets`) together with a variable.

This removes the need for the `ExprRec` representation, thus reducing duplication and potentially opening the way to n-ary operations.

To work around a bug in Lean, this PR also changes a Context to just a list of types, instead of being `Erased`. This change is localized to just a few lines in `ErasedContext.lean`, and should be easy to revert once the bug is fixed.