### PR TITLE
FHE New Representation

### DIFF
--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -12,8 +12,8 @@ https://eprint.iacr.org/2012/144
 -/
 import Mathlib.RingTheory.Polynomial.Quotient
 import Mathlib.RingTheory.Ideal.Quotient
+import Mathlib.RingTheory.Ideal.QuotientOperations
 import Mathlib.Data.Zmod.Basic
-import Mathlib.Data.Nat.Cast.WithTop
 import SSA.Experimental.IntrinsicAsymptotics
 
 open Polynomial -- for R[X] notation
@@ -101,22 +101,21 @@ noncomputable abbrev R.one {q n : Nat} : R q n := R.fromPoly 1
 noncomputable instance {q n : Nat} : Zero (R q n) := ⟨R.zero⟩
 noncomputable instance {q n : Nat} : One (R q n) := ⟨R.one⟩
 
-private noncomputable def R.representative' {q n} : R q n → (ZMod q)[X] := Function.surjInv Ideal.Quotient.mk_surjective
-
+private noncomputable def R.representative' : R q n → (ZMod q)[X] := Function.surjInv Ideal.Quotient.mk_surjective
 /--
 The representative of `a : R q n` is the (unique) polynomial `p : ZMod q[X]` of degree `< 2^n`
  such that `R.fromPoly p = a`.
 -/
-noncomputable def R.representative {q n} : R q n → (ZMod q)[X] := fun x => R.representative' x %ₘ (f q n)
+noncomputable def R.representative : R q n → (ZMod q)[X] := fun x => R.representative' q n x %ₘ (f q n)
 
 /--
 `R.representative` is in fact a representative of the equivalence class.
 -/
-theorem R.rep_fromPoly_eq : forall a : R q n, (R.fromPoly (n:=n) (R.representative a)) = a := by
+theorem R.rep_fromPoly_eq : forall a : R q n, (R.fromPoly (n:=n) (R.representative q n a)) = a := by
  intro a 
  simp [R.representative]
  rw [Polynomial.modByMonic_eq_sub_mul_div _ (f_monic q n)]
- rw [RingHom.map_sub (R.fromPoly (n:=n)) _ _]
+ rw [RingHom.map_sub (R.fromPoly (q := q) (n:=n)) _ _]
  have hker : forall x, fromPoly (f q n * x) = 0 := by
    intro x
    unfold fromPoly
@@ -128,9 +127,14 @@ theorem R.rep_fromPoly_eq : forall a : R q n, (R.fromPoly (n:=n) (R.representati
  simp
  apply Function.surjInv_eq
 
+/--
+Characterization theorem for the representative.
+Taking the representative of the equivalence class of a polynomial  `a : (ZMod q)[X]` is 
+the same as taking the remainder of `a` modulo `f q n`.
+-/
 theorem R.fromPoly_rep_eq : forall a : (ZMod q)[X], (R.fromPoly (n:=n) a).representative = a %ₘ (f q n) := by
 simp [R.representative]
--- by definition of representative, there exists an i ∈ (Ideal.span {f q n}) such that
+-- by definition of representative (and some isomorphism theorem), there exists an i ∈ (Ideal.span {f q n}) such that
 -- a = (R.representative' (R.fromPoly a)) + i
 sorry --rw  [R.rep'_fromPoly_eq]
 
@@ -138,7 +142,7 @@ sorry --rw  [R.rep'_fromPoly_eq]
 /--
 The representative of `a : R q n` is the (unique) reperesntative with degree `< 2^n`.
 -/
-theorem R.rep_degree_lt_n : forall a : R q n, (R.representative a).degree < 2^n := by
+theorem R.rep_degree_lt_n : forall a : R q n, (R.representative q n a).degree < 2^n := by
   intro a
   simp [R.representative]
   rw [← f_deg_eq q n]

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -42,7 +42,7 @@ theorem WithBot.npow_coe_eq_npow (n : Nat) (x : ℕ) : (WithBot.some x : WithBot
   done
 
 noncomputable def f : (ZMod q)[X] := X^(2^n) + 1
-/-! Charaterizing `f`: `f` is monic of degree `2^n` -/
+/-- Charaterizing `f`: `f` is monic of degree `2^n` -/
 theorem f_deg_eq : (f q n).degree = 2^n := by
   simp [f]
   rw [Polynomial.degree_add_eq_left_of_degree_lt]

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -142,7 +142,7 @@ Characterization theorem for the representative.
 Taking the representative of the equivalence class of a polynomial  `a : (ZMod q)[X]` is 
 the same as taking the remainder of `a` modulo `f q n`.
 -/
-theorem R.fromPoly_rep_eq : forall a : (ZMod q)[X], (R.fromPoly (n:=n) a).representative = a %ₘ (f q n) := by
+theorem R.representative_fromPoly : forall a : (ZMod q)[X], (R.fromPoly (n:=n) a).representative = a %ₘ (f q n) := by
   intro a
   simp [R.representative]
   have ⟨i,⟨hiI,hi_eq⟩⟩ := R.fromPoly_rep'_eq q n a

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -31,6 +31,21 @@ variable (q t : Nat) [Fact (q > 1)] (n : Nat)
 -- Question: Can we make something like d := 2^n work as a macro?
 --
 
+theorem WithBot.coe_mul_coe {a b : α} [DecidableEq α] [MulZeroClass α] : ↑a * ↑b = (↑(a * b) : WithBot α)  := by
+  simp [WithBot.mul_def]
+
+theorem WithBot.npow_coe_eq_npow (n : Nat) (x : ℕ) : (WithBot.some x : WithBot ℕ) ^ n = WithBot.some (x ^ n) := by
+  --rw [← WithBot.some_eq_coe, WithBot.some]
+  induction n with
+    | zero => simp
+    | succ n ih =>  
+        rw [pow_succ'', ih, WithBot.coe_mul_coe]
+        rw [← WithBot.some_eq_coe, WithBot.some]
+        apply Option.some_inj.2
+        rw [Nat.pow_succ]
+        ring
+  done
+
 noncomputable def f : (ZMod q)[X] := X^(2^n) + 1
 
 theorem f_deg_eq : (f q n).degree = 2^n := by
@@ -48,9 +63,10 @@ theorem f_deg_eq : (f q n).degree = 2^n := by
   have h2 : @OfNat.ofNat (WithBot ℕ) 2 instOfNat = @WithBot.some ℕ 2 := by
     simp [OfNat.ofNat]
   have h2n : @HPow.hPow (WithBot ℕ) ℕ (WithBot ℕ) instHPow 2 n = @WithBot.some ℕ (@HPow.hPow ℕ ℕ ℕ instHPow 2 n) := by
-    simp [h2, HPow.hPow]
+    rw [h2, WithBot.npow_coe_eq_npow]
   rw [h0, h2n]
   exact h'
+  done
 
 theorem f_monic : Monic (f q n) := by 
   simp [Monic]; unfold leadingCoeff; unfold natDegree; rw [f_deg_eq]
@@ -58,7 +74,7 @@ theorem f_monic : Monic (f q n) := by
   have h2 : @OfNat.ofNat (WithBot ℕ) 2 instOfNat = @WithBot.some ℕ 2 := by
     simp [OfNat.ofNat]
   have h2n : @HPow.hPow (WithBot ℕ) ℕ (WithBot ℕ) instHPow 2 n = @WithBot.some ℕ (@HPow.hPow ℕ ℕ ℕ instHPow 2 n) := by
-    simp [h2, HPow.hPow]
+    simp [h2, WithBot.npow_coe_eq_npow]
   rw [h2n]
   rw [WithBot.unbot'_coe]
   simp

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -13,6 +13,7 @@ https://eprint.iacr.org/2012/144
 import Mathlib.RingTheory.Polynomial.Quotient
 import Mathlib.RingTheory.Ideal.Quotient
 import Mathlib.Data.Zmod.Basic
+import Mathlib.Data.Nat.Cast.WithTop
 import SSA.Experimental.IntrinsicAsymptotics
 
 open Polynomial -- for R[X] notation
@@ -40,8 +41,16 @@ theorem f_deg_eq : (f q n).degree = 2^n := by
   simp [Polynomial.degree_one]
   have h : 0 < 2^n := by
     apply Nat.one_le_two_pow
-  try apply h -- TODO: lift to preorder
-  sorry
+  have h' := WithBot.coe_lt_coe.2 h
+  simp [Preorder.toLT, WithBot.preorder]
+  have h0 : @OfNat.ofNat (WithBot ℕ) 0 Zero.toOfNat0  = @WithBot.some ℕ 0 := by
+    simp [OfNat.ofNat]
+  have h2 : @OfNat.ofNat (WithBot ℕ) 2 instOfNat = @WithBot.some ℕ 2 := by
+    simp [OfNat.ofNat]
+  have h2n : @HPow.hPow (WithBot ℕ) ℕ (WithBot ℕ) instHPow 2 n = @WithBot.some ℕ (@HPow.hPow ℕ ℕ ℕ instHPow 2 n) := by
+    simp [h2, HPow.hPow]
+  rw [h0, h2n]
+  exact h'
 
 theorem f_monic : Monic (f q n) := by 
   simp [Monic]; unfold leadingCoeff; unfold natDegree; rw [f_deg_eq]

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -55,7 +55,18 @@ theorem f_deg_eq : (f q n).degree = 2^n := by
 theorem f_monic : Monic (f q n) := by 
   simp [Monic]; unfold leadingCoeff; unfold natDegree; rw [f_deg_eq]
   simp [coeff_add, f]
-  sorry
+  have h2 : @OfNat.ofNat (WithBot ℕ) 2 instOfNat = @WithBot.some ℕ 2 := by
+    simp [OfNat.ofNat]
+  have h2n : @HPow.hPow (WithBot ℕ) ℕ (WithBot ℕ) instHPow 2 n = @WithBot.some ℕ (@HPow.hPow ℕ ℕ ℕ instHPow 2 n) := by
+    simp [h2, HPow.hPow]
+  rw [h2n]
+  rw [WithBot.unbot'_coe]
+  simp
+  have h2nne0 : 2^n ≠ 0 := by 
+    apply Nat.pos_iff_ne_zero.1
+    apply Nat.one_le_two_pow
+  rw [← Polynomial.C_1, Polynomial.coeff_C]
+  simp [h2nne0]
 
 /--
 The basic ring of interest in this dialect is `R q n` which corresponds to

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -42,7 +42,7 @@ theorem WithBot.npow_coe_eq_npow (n : Nat) (x : ℕ) : (WithBot.some x : WithBot
   done
 
 noncomputable def f : (ZMod q)[X] := X^(2^n) + 1
-
+/-! Charaterizing `f`: `f` is monic of degree `2^n` -/
 theorem f_deg_eq : (f q n).degree = 2^n := by
   simp [f]
   rw [Polynomial.degree_add_eq_left_of_degree_lt]

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -106,7 +106,8 @@ noncomputable def R.representative : R q n → (ZMod q)[X] := fun x => R.represe
 /--
 `R.representative` is in fact a representative of the equivalence class.
 -/
-theorem R.rep_fromPoly_eq : forall a : R q n, (R.fromPoly (n:=n) (R.representative q n a)) = a := by
+@[simp]
+theorem R.fromPoly_representative : forall a : R q n, (R.fromPoly (n:=n) (R.representative q n a)) = a := by
  intro a 
  simp [R.representative]
  rw [Polynomial.modByMonic_eq_sub_mul_div _ (f_monic q n)]

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -42,7 +42,8 @@ theorem WithBot.npow_coe_eq_npow (n : Nat) (x : ℕ) : (WithBot.some x : WithBot
   done
 
 noncomputable def f : (ZMod q)[X] := X^(2^n) + 1
-/-- Charaterizing `f`: `f` is monic of degree `2^n` -/
+
+/-- Charaterizing `f`: `f` has degree `2^n` -/
 theorem f_deg_eq : (f q n).degree = 2^n := by
   simp [f]
   rw [Polynomial.degree_add_eq_left_of_degree_lt]
@@ -63,21 +64,14 @@ theorem f_deg_eq : (f q n).degree = 2^n := by
   exact h'
   done
 
+/-- Charaterizing `f`: `f` is monic -/
 theorem f_monic : Monic (f q n) := by 
-  simp [Monic]; unfold leadingCoeff; unfold natDegree; rw [f_deg_eq]
-  simp [coeff_add, f]
-  have h2 : @OfNat.ofNat (WithBot ℕ) 2 instOfNat = @WithBot.some ℕ 2 := by
-    simp [OfNat.ofNat]
-  have h2n : @HPow.hPow (WithBot ℕ) ℕ (WithBot ℕ) instHPow 2 n = @WithBot.some ℕ (@HPow.hPow ℕ ℕ ℕ instHPow 2 n) := by
-    simp [h2, WithBot.npow_coe_eq_npow]
-  rw [h2n]
-  rw [WithBot.unbot'_coe]
-  simp
-  have h2nne0 : 2^n ≠ 0 := by 
-    apply Nat.pos_iff_ne_zero.1
-    apply Nat.one_le_two_pow
-  rw [← Polynomial.C_1, Polynomial.coeff_C]
-  simp [h2nne0]
+  have hn : 2^n = (2^n - 1) + 1 := by rw [Nat.sub_add_cancel (Nat.one_le_two_pow n)]
+  have hn_minus_1 : degree 1 ≤ ↑(2^n - 1) := by
+    rw [Polynomial.degree_one (R := (ZMod q))]; simp
+  rw [f, hn]
+  apply Polynomial.monic_X_pow_add hn_minus_1
+  done
 
 /--
 The basic ring of interest in this dialect is `R q n` which corresponds to


### PR DESCRIPTION
This PR migrates the FHE use case to the `ICom` data structure from `IntrinsicAsymptotics`. It also removes all the remaining axioms (and sorries) from the file.